### PR TITLE
Notification enabled status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 7.0.0
+
+Major breaking update - [Migration guide](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-6.x-to-7.x)
+
+- Updated the target sdk version to 33
+- Updated and renamed the pushRegister API to pushRequestDeviceToken which tries to request a notification permission on devices running Android version >= 13
+- Updated the push message handlers to return a boolean, indicating whether the message was handled by Optimove
+
 ## 6.1.1
 
 - Fixed an error when links are not opening on Android versions higher than 11

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.java
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.java
@@ -38,6 +38,6 @@ public class MyApplication extends Application {
     // Shouldn't be called unless explicitly told to
     Optimove.enableStagingRemoteLogs();
 
-    Optimove.getInstance().pushRegister();
+    Optimove.getInstance().pushRequestDeviceToken();
   }
 }

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=6.2.0
-sdk_version_code=60200
+sdk_version=7.0.0
+sdk_version_code=70000
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=6.1.1
-sdk_version_code=60101
+sdk_version=6.2.0
+sdk_version_code=60200
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/optimove-sdk/build.gradle
+++ b/OptimoveSDK/optimove-sdk/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'com.android.library'
 group = 'com.optimove.sdk'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode Integer.parseInt("$sdk_version_code")
         versionName "$sdk_version"
         consumerProguardFiles 'optimove-proguard-rules.pro'

--- a/OptimoveSDK/optimove-sdk/src/main/AndroidManifest.xml
+++ b/OptimoveSDK/optimove-sdk/src/main/AndroidManifest.xml
@@ -22,6 +22,12 @@
             android:excludeFromRecents="true"
             android:theme="@android:style/Theme.Translucent"
             android:exported="false" />
+        <activity
+            android:name="com.optimove.android.optimobile.RequestNotificationPermissionActivity"
+            android:noHistory="true"
+            android:excludeFromRecents="true"
+            android:theme="@style/Optimove.Optipush.Transparent"
+            android:exported="false" />
     </application>
 
     <!-- https://developer.android.com/training/package-visibility/use-cases#check-browser-available -->

--- a/OptimoveSDK/optimove-sdk/src/main/AndroidManifest.xml
+++ b/OptimoveSDK/optimove-sdk/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:fullBackupContent="@xml/optimove_backup_rules"

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
@@ -472,10 +472,10 @@ final public class Optimove {
     //-- Push APIs
 
     /**
-     * Used to register the device installation with FCM to receive push notifications
+     * Used to register the device installation to receive push notifications. Prompts a notification permission request
      */
-    public void pushRegister() {
-        Optimobile.pushRegister(context);
+    public void pushRequestDeviceToken() {
+        Optimobile.pushRequestDeviceToken(context);
     }
 
     /**

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsContract.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsContract.java
@@ -38,6 +38,7 @@ final class AnalyticsContract {
     static final String EVENT_TYPE_ASSOCIATE_USER = "k.stats.userAssociated";
     static final String EVENT_TYPE_CLEAR_USER_ASSOCIATION = "k.stats.userAssociationCleared";
     static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";
+    static final String EVENT_TYPE_PUSH_NOTIFICATION_ENABLEMENT_CHANGED = "k.push.notificationEnablementChanged";
     static final String EVENT_TYPE_PUSH_DEVICE_UNSUBSCRIBED = "k.push.deviceUnsubscribed";
     static final String EVENT_TYPE_MESSAGE_DISMISSED = "k.message.dismissed";
     static final String EVENT_TYPE_MESSAGE_OPENED = "k.message.opened";

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AppStateWatcher.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AppStateWatcher.java
@@ -55,6 +55,11 @@ class AppStateWatcher implements Application.ActivityLifecycleCallbacks {
         }
     }
 
+    @UiThread
+    public void unregisterListener(AppStateChangedListener listener) {
+        listeners.remove(listener);
+    }
+
     @Override
     public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) { /* noop */ }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/FirebaseMessageHandler.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/FirebaseMessageHandler.java
@@ -30,10 +30,11 @@ public class FirebaseMessageHandler {
      *
      * @param context
      * @param remoteMessage
+     * @return whether the message was handled by Optimove
      */
-    public static void onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
+    public static boolean onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
         if (null == remoteMessage) {
-            return;
+            return false;
         }
 
         Optimobile.log(TAG, "Received a push message");
@@ -43,7 +44,7 @@ public class FirebaseMessageHandler {
         String customStr = bundle.get("custom");
 
         if (null == customStr) {
-            return;
+            return false;
         }
 
         // Extract bundle
@@ -63,8 +64,9 @@ public class FirebaseMessageHandler {
             buttons = data.optJSONArray("k.buttons");
 
         } catch (JSONException e) {
-            Optimobile.log(TAG, "Push received had no ID/data/uri or was incorrectly formatted, ignoring...");
-            return;
+            Optimobile.log(TAG, "Push received shouldn't be processed by Optimove or was incorrectly" +
+                    "formatted, ignoring...");
+            return false;
         }
 
         String bgn = bundle.get("bgn");
@@ -89,5 +91,6 @@ public class FirebaseMessageHandler {
         intent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
 
         context.sendBroadcast(intent);
+        return true;
     }
 }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/HmsMessageHandler.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/HmsMessageHandler.java
@@ -27,10 +27,11 @@ public class HmsMessageHandler {
      * the appropriate com.optimove.push Intent
      * @param context
      * @param remoteMessage
+     * @return whether the message was handled by Optimove
      */
-    public static void onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
+    public static boolean onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
         if (null == remoteMessage) {
-            return;
+            return false;
         }
 
         Optimobile.log(TAG, "Received a push message");
@@ -41,11 +42,11 @@ public class HmsMessageHandler {
             bundle = new JSONObject(remoteMessage.getData());
         } catch (JSONException e) {
             e.printStackTrace();
-            return;
+            return false;
         }
 
         if (!bundle.has("custom") || bundle.isNull("custom")) {
-            return;
+            return false;
         }
 
         int id;
@@ -63,8 +64,9 @@ public class HmsMessageHandler {
             id = data.getJSONObject("k.message").getJSONObject("data").getInt("id");
             buttons = data.optJSONArray("k.buttons");
         } catch (JSONException e) {
-            Optimobile.log(TAG, "Push received had no ID/data/uri or was incorrectly formatted, ignoring...");
-            return;
+            Optimobile.log(TAG, "Push received shouldn't be processed by Optimove or was incorrectly formatted, " +
+                    "ignoring...");
+            return false;
         }
 
         String bgn = optNullableString(bundle, "bgn");
@@ -89,6 +91,7 @@ public class HmsMessageHandler {
         intent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
 
         context.sendBroadcast(intent);
+        return true;
     }
 
     private static String optNullableString(@NonNull JSONObject object, @NonNull String name) {

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessageView.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessageView.java
@@ -549,7 +549,7 @@ class InAppMessageView extends WebViewClient {
                 case BUTTON_ACTION_PUSH_REGISTER:
                     presenter.cancelCurrentPresentationQueue();
 
-                    Optimobile.pushRegister(currentActivity);
+                    Optimobile.pushRequestDeviceToken(currentActivity);
                     return;
             }
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -252,11 +252,11 @@ public final class Optimobile {
     //-- Push APIs
 
     /**
-     * Used to register the device installation with FCM to receive push notifications
+     * Used to register the device installation to receive push notifications. Prompts a notification permission request
      *
      * @param context
      */
-    public static void pushRegister(Context context) {
+    public static void pushRequestDeviceToken(Context context) {
         PushRegistration.RegisterTask task = new PushRegistration.RegisterTask(context);
         executorService.submit(task);
     }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -336,7 +336,7 @@ public final class Optimobile {
     }
 
 
-    public static void notificationEnablementStatusChanged(@NonNull Context context, boolean notificationsEnabled) {
+    static void notificationEnablementStatusChanged(@NonNull Context context, boolean notificationsEnabled) {
         JSONObject props = new JSONObject();
 
         try {

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -18,6 +18,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -325,11 +326,7 @@ public final class Optimobile {
             props.put("token", token);
             props.put("type", type.getValue());
             props.put("package", context.getPackageName());
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                props.put("areNotificationsEnabled",
-                        ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE)).areNotificationsEnabled());
-            }
-
+            props.put("areNotificationsEnabled", NotificationManagerCompat.from(context).areNotificationsEnabled());
         } catch (JSONException e) {
             e.printStackTrace();
             return;

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -332,7 +332,7 @@ public final class Optimobile {
             return;
         }
 
-        trackEvent(context, AnalyticsContract.EVENT_TYPE_PUSH_DEVICE_REGISTERED, props, System.currentTimeMillis(), true);
+        trackEventImmediately(context, AnalyticsContract.EVENT_TYPE_PUSH_DEVICE_REGISTERED, props);
     }
 
 
@@ -346,7 +346,7 @@ public final class Optimobile {
             return;
         }
 
-        trackEvent(context, AnalyticsContract.EVENT_TYPE_PUSH_NOTIFICATION_ENABLEMENT_CHANGED, props, System.currentTimeMillis(), true);
+        trackEventImmediately(context, AnalyticsContract.EVENT_TYPE_PUSH_NOTIFICATION_ENABLEMENT_CHANGED, props);
     }
 
     /**

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -1,7 +1,9 @@
 
 package com.optimove.android.optimobile;
 
+import android.app.Activity;
 import android.app.Application;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -323,12 +325,31 @@ public final class Optimobile {
             props.put("token", token);
             props.put("type", type.getValue());
             props.put("package", context.getPackageName());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                props.put("areNotificationsEnabled",
+                        ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE)).areNotificationsEnabled());
+            }
+
         } catch (JSONException e) {
             e.printStackTrace();
             return;
         }
 
         trackEvent(context, AnalyticsContract.EVENT_TYPE_PUSH_DEVICE_REGISTERED, props, System.currentTimeMillis(), true);
+    }
+
+
+    public static void notificationEnablementStatusChanged(@NonNull Context context, boolean notificationsEnabled) {
+        JSONObject props = new JSONObject();
+
+        try {
+            props.put("notificationsEnabled", notificationsEnabled);
+        } catch (JSONException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        trackEvent(context, AnalyticsContract.EVENT_TYPE_PUSH_NOTIFICATION_ENABLEMENT_CHANGED, props, System.currentTimeMillis(), true);
     }
 
     /**

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
@@ -93,10 +93,12 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             this.onBackgroundPush(context, pushMessage);
         }
 
-        if (!pushMessage.hasTitleAndMessage() || (!notificationsEnabled(context))) {
-            return;
+        if (pushMessage.hasTitleAndMessage() && notificationsEnabled(context)) {
+            processPushMessage(context, pushMessage);
         }
+    }
 
+    private void processPushMessage(Context context, PushMessage pushMessage) {
         Notification.Builder builder = getNotificationBuilder(context, pushMessage);
         if (null == builder) {
             return;

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
@@ -93,8 +93,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             this.onBackgroundPush(context, pushMessage);
         }
 
-        if (!pushMessage.hasTitleAndMessage()) {
-            // Always show Notification if has title + message
+        if (!pushMessage.hasTitleAndMessage() || (!notificationsEnabled(context))) {
             return;
         }
 
@@ -112,6 +111,14 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         }
 
         this.showNotification(context, pushMessage, builder.build());
+    }
+
+    private boolean notificationsEnabled(Context context){
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true;
+        }
+
+        return ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE)).areNotificationsEnabled();
     }
 
     private void showNotification(Context context, PushMessage pushMessage, Notification notification) {

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
@@ -21,6 +21,7 @@ import android.os.Build;
 import android.util.DisplayMetrics;
 
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 
 import com.optimove.android.Optimove;
 import com.optimove.android.OptimoveConfig;
@@ -93,7 +94,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             this.onBackgroundPush(context, pushMessage);
         }
 
-        if (pushMessage.hasTitleAndMessage() && notificationsEnabled(context)) {
+        if (pushMessage.hasTitleAndMessage() && NotificationManagerCompat.from(context).areNotificationsEnabled()) {
             processPushMessage(context, pushMessage);
         }
     }
@@ -113,14 +114,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         }
 
         this.showNotification(context, pushMessage, builder.build());
-    }
-
-    private boolean notificationsEnabled(Context context){
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            return true;
-        }
-
-        return ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE)).areNotificationsEnabled();
     }
 
     private void showNotification(Context context, PushMessage pushMessage, Notification notification) {

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushRegistration.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushRegistration.java
@@ -1,10 +1,14 @@
 package com.optimove.android.optimobile;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.PermissionChecker;
 
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
@@ -46,6 +50,7 @@ final class PushRegistration {
 
             switch (api) {
                 case FCM:
+                    RequestNotificationPermissionActivity.request(context);
                     this.registerFcm(context, instance);
                     break;
                 case HMS:

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
@@ -24,7 +24,7 @@ public class RequestNotificationPermissionActivity extends Activity {
     protected void onStart() {
         super.onStart();
 
-        if (Build.VERSION.SDK_INT < 33) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             finish();
             return;
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
@@ -1,0 +1,89 @@
+package com.optimove.android.optimobile;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+public class RequestNotificationPermissionActivity extends Activity {
+
+    private static final int REQ_CODE = 1;
+    private static final String TAG = RequestNotificationPermissionActivity.class.getName();
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+        if (Build.VERSION.SDK_INT >= 33) {
+            boolean shouldShow = shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS);
+
+            Log.d(TAG, "Should show perms req rationale? " + (shouldShow ? "YES" : "NO"));
+
+            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQ_CODE);
+        } else {
+            finish();
+        }
+    }
+
+    static void request(Context context) {
+        // TODO: handle multiple requests / app lifecycle changes
+        int granted = PackageManager.PERMISSION_GRANTED;
+
+        if (Build.VERSION.SDK_INT >= 33) {
+            granted = context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS);
+        }
+
+        if (granted == PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
+        Optimobile.handler.post(() -> {
+            OptimobileInitProvider.getAppStateWatcher().registerListener(new AppStateWatcher.AppStateChangedListener() {
+                @Override
+                public void appEnteredForeground() {
+
+                }
+
+                @Override
+                public void activityAvailable(@NonNull Activity activity) {
+                    Intent intent = new Intent(context, RequestNotificationPermissionActivity.class);
+                    intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+                    activity.startActivity(intent);
+                    OptimobileInitProvider.getAppStateWatcher().unregisterListener(this);
+                }
+
+                @Override
+                public void activityUnavailable(@NonNull Activity activity) {
+
+                }
+
+                @Override
+                public void appEnteredBackground() {
+
+                }
+            });
+        });
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        boolean shouldShow = false;
+        if (android.os.Build.VERSION.SDK_INT >= 33) {
+            shouldShow = shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS);
+        }
+
+        Log.d(TAG, String.format("%d %s %d %b", requestCode, permissions[0], grantResults[0], shouldShow));
+
+        finish();
+    }
+}

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
@@ -13,6 +13,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
+import java.util.Locale;
+
 public class RequestNotificationPermissionActivity extends Activity {
 
     private static final int REQ_CODE = 1;
@@ -22,59 +24,20 @@ public class RequestNotificationPermissionActivity extends Activity {
     protected void onStart() {
         super.onStart();
 
-        if (Build.VERSION.SDK_INT >= 33) {
-            boolean shouldShow = shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS);
-
-            Log.d(TAG, "Should show perms req rationale? " + (shouldShow ? "YES" : "NO"));
-
-            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQ_CODE);
-        } else {
+        if (Build.VERSION.SDK_INT < 33) {
             finish();
-        }
-    }
-
-    static void request(Context context) {
-        // TODO: handle multiple requests / app lifecycle changes
-        int granted = PackageManager.PERMISSION_GRANTED;
-
-        if (Build.VERSION.SDK_INT >= 33) {
-            granted = context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS);
-        }
-
-        if (granted == PackageManager.PERMISSION_GRANTED) {
             return;
         }
 
-        Optimobile.handler.post(() -> {
-            OptimobileInitProvider.getAppStateWatcher().registerListener(new AppStateWatcher.AppStateChangedListener() {
-                @Override
-                public void appEnteredForeground() {
+        boolean shouldShow = shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS);
+        Optimobile.log(TAG, "Should show perms req rationale? " + (shouldShow ? "YES" : "NO"));
 
-                }
-
-                @Override
-                public void activityAvailable(@NonNull Activity activity) {
-                    Intent intent = new Intent(context, RequestNotificationPermissionActivity.class);
-                    intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                    activity.startActivity(intent);
-                    OptimobileInitProvider.getAppStateWatcher().unregisterListener(this);
-                }
-
-                @Override
-                public void activityUnavailable(@NonNull Activity activity) {
-
-                }
-
-                @Override
-                public void appEnteredBackground() {
-
-                }
-            });
-        });
+        requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQ_CODE);
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
         boolean shouldShow = false;
@@ -82,8 +45,9 @@ public class RequestNotificationPermissionActivity extends Activity {
             shouldShow = shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS);
         }
 
-        Log.d(TAG, String.format("%d %s %d %b", requestCode, permissions[0], grantResults[0], shouldShow));
-
+        Optimobile.log(TAG, String.format(Locale.getDefault(), "%d %s %d %b", requestCode, permissions[0],
+                grantResults[0],
+                shouldShow));
         finish();
     }
 }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/RequestNotificationPermissionActivity.java
@@ -39,15 +39,6 @@ public class RequestNotificationPermissionActivity extends Activity {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-
-        boolean shouldShow = false;
-        if (android.os.Build.VERSION.SDK_INT >= 33) {
-            shouldShow = shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS);
-        }
-
-        Optimobile.log(TAG, String.format(Locale.getDefault(), "%d %s %d %b", requestCode, permissions[0],
-                grantResults[0],
-                shouldShow));
         finish();
     }
 }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/SessionHelper.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/SessionHelper.java
@@ -9,6 +9,7 @@ import android.content.SharedPreferences;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
@@ -62,10 +63,6 @@ public class SessionHelper implements AppStateWatcher.AppStateChangedListener {
     }
 
     private void checkNotificationEnablementForStatusChange(){
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            return;
-        }
-
         final Context context = mContextRef.get();
         if (null == context) {
             return;
@@ -75,8 +72,7 @@ public class SessionHelper implements AppStateWatcher.AppStateChangedListener {
 
         boolean persistedNotificationsEnabled = prefs.getBoolean(SharedPrefs.KEY_NOTIFICATIONS_ENABLEMENT_STATUS,
                 false);
-        boolean currentNotificationsEnabled =
-                ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE)).areNotificationsEnabled();
+        boolean currentNotificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled();
 
         if (persistedNotificationsEnabled == currentNotificationsEnabled) {
             return;

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/SharedPrefs.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/SharedPrefs.java
@@ -6,4 +6,5 @@ final class SharedPrefs {
     static final String IN_APP_ENABLED = "in_app_enabled";
     static final String IN_APP_LAST_SYNC_TIME = "in_app_last_sync_time";
     static final String DEFERRED_LINK_CHECKED_KEY = "optimobile_ddl_checked";
+    static final String KEY_NOTIFICATIONS_ENABLEMENT_STATUS = "notifications_enabled";
 }

--- a/OptimoveSDK/optimove-sdk/src/main/res/values/styles.xml
+++ b/OptimoveSDK/optimove-sdk/src/main/res/values/styles.xml
@@ -7,5 +7,6 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:backgroundDimEnabled">false</item>
         <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowAnimationStyle">@null</item>
     </style>
 </resources>

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ In this guide we will discuss the steps necessary to implement the Optimove Andr
 
 ### Migrations
 
-1. [Migration from 5.x to 6.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-5.x-to-6.x)
-2. [Migration from 4.x to 5.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-4.x-to-5.x)
-3. [Migration from 3.x to 4.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-3.x-to-4.x)
-4. [Migration from 2.x to 3.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-2.x-to-3.x)
+1. [Migration from 6.x to 7.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-6.x-to-7.x)
+2. [Migration from 5.x to 6.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-5.x-to-6.x)
+3. [Migration from 4.x to 5.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-4.x-to-5.x)
+4. [Migration from 3.x to 4.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-3.x-to-4.x)
+5. [Migration from 2.x to 3.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-2.x-to-3.x)
 
 ## License
 


### PR DESCRIPTION
### Description of Changes

1. Updated the target sdk version to 33
2. Updated and renamed the pushRegister API to pushRequestDeviceToken which tries to request a notification permission on devices running Android version >= 13
3. Updated the push message handlers to return a boolean, indicating whether the message was handled by Optimove

### Breaking Changes

- Updated and renamed the pushRegister API to pushRequestDeviceToken which tries to request a notification permission on devices running Android version >= 13

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [x] CHANGELOG.md

### Integration tests

*T&T Only*

- [ ] ~~Init SDK with only optimove credentials~~
- [ ] ~~Associate customer~~
- [ ] ~~Associate email~~
- [ ] ~~Track events~~

*Mobile Only*

- [ ] ~~Init SDK with all credentials~~
- [ ] ~~Track events~~
- [ ] ~~Associate customer (verify both backends)~~
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] ~~Receive / trigger the content extension, render image and action buttons for push~~
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] ~~With app installed, trigger deep link handler~~
- [ ] ~~With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler~~

*Combined*

- [ ] ~~Track event for T&T, verify push received~~
- [ ] ~~Trigger scheduled campaign, verify push received~~
- [ ] ~~Trigger scheduled campaign, verify In-App received~~

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged