### PR TITLE
Event timestamp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.1
+
+- Fixed the Optistream event to keep the original timestamp
+
 ## 7.1.0
 
 - In order to support geofencing and beacons, add public API methods to track location and beacon proximity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.2
+
+- Fix In-App Message null Intent handling
+
 ## 7.1.1
 
 - Fixed the Optistream event to keep the original timestamp

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.1.1
-sdk_version_code=70101
+sdk_version=7.1.2
+sdk_version_code=70102
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.1.0
-sdk_version_code=70100
+sdk_version=7.1.1
+sdk_version_code=70101
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/main/common/OptistreamEventBuilder.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/main/common/OptistreamEventBuilder.java
@@ -44,7 +44,7 @@ public class OptistreamEventBuilder {
                 .withOrigin(OptistreamEventBuilder.Constants.ORIGIN)
                 .withUserId(userInfo.getUserId())
                 .withVisitorId(userInfo.getVisitorId())
-                .withTimestamp(simpleDateFormat.format(new Date()))
+                .withTimestamp(simpleDateFormat.format(new Date(optimoveEvent.getTimestamp())))
                 .withContext(optimoveEvent.getParameters());
 
         OptistreamEvent.Metadata metadata = new OptistreamEvent.Metadata(isRealtime, userInfo.getFirstVisitorDate(),

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
@@ -50,8 +50,12 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
             currentActivity = activity;
         }
 
+        int tickleId = -1;
+
         Intent i = currentActivity.getIntent();
-        int tickleId = i.getIntExtra(PushBroadcastReceiver.EXTRAS_KEY_TICKLE_ID, -1);
+        if (null != i) {
+            tickleId = i.getIntExtra(PushBroadcastReceiver.EXTRAS_KEY_TICKLE_ID, -1);
+        }
 
         if (-1 != tickleId) {
             InAppMessageService.readAndPresentMessages(context, false, tickleId);


### PR DESCRIPTION
When an event is reported it generates a timestamp. Just before the event is sent to the backed, it is transformed to Optistream event and the timestamp is regenerated. Usually this isn't a problem cause the timestamps are equal. If the mobile config file arrives after the first generation of the event, there is a potential difference between the timestamps.