### PR TITLE
Add null check to In-App Message Intent handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.2
+
+- Fix In-App Message null Intent handling
+
 ## 7.1.1
 
 - Fixed the Optistream event to keep the original timestamp

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.1.1
-sdk_version_code=70101
+sdk_version=7.1.2
+sdk_version_code=70102
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
@@ -50,8 +50,12 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
             currentActivity = activity;
         }
 
+        int tickleId = -1;
+
         Intent i = currentActivity.getIntent();
-        int tickleId = i.getIntExtra(PushBroadcastReceiver.EXTRAS_KEY_TICKLE_ID, -1);
+        if (null != i) {
+            tickleId = i.getIntExtra(PushBroadcastReceiver.EXTRAS_KEY_TICKLE_ID, -1);
+        }
 
         if (-1 != tickleId) {
             InAppMessageService.readAndPresentMessages(context, false, tickleId);


### PR DESCRIPTION
### Description of Changes

It was assumed that the Intent from the current Activity will never be `null`.

In practise, we have observed the following crash:

```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.content.Intent.getIntExtra(java.lang.String, int)' on a null object reference
        at com.optimove.android.optimobile.InAppMessagePresenter.activityAvailable(InAppMessagePresenter.java:54)
        at com.optimove.android.optimobile.AppStateWatcher.onActivityResumed(AppStateWatcher.java:82)
        at android.app.Application.dispatchActivityResumed(Application.java:416)
        at android.app.Activity.dispatchActivityResumed(Activity.java:1397)
        at android.app.Activity.onResume(Activity.java:1950)
        at androidx.fragment.app.FragmentActivity.onResume(FragmentActivity.java:434)
```

It is not clearly documented if an Activity's current Intent can be null, but nothing prevents it being set to null with Activity#setIntent(null).

So, we add a guard that prevents trying to unpack the IAM tickle ID if the Intent of the current Activity was null.

Note we don't abort the foreground handler so that existing behaviour of IAM presentation remains unchanged. Early abort could potentially leave an inconsistent view state for the presentation queue.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [x] CHANGELOG.md
- [x] gradle.properties
- [ ] ~~add links to newly created wiki pages to readme~~

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
