### PR TITLE
Add in-app display mode and API to enable pausing & resuming in-app message display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.2.0
+
+- Add ability to pause & resume in-app message display (#38)
+
 ## 7.1.1
 
 - Fixed In-App Message null Intent handling

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -9,7 +9,7 @@
 org.gradle.jvmargs=-Xmx1536m
 
 sdk_version=7.2.0
-sdk_version_code=72020
+sdk_version_code=70200
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.1.1
-sdk_version_code=70101
+sdk_version=7.2.0
+sdk_version_code=72020
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -6,12 +6,10 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.optimove.android.main.common.TenantInfo;
 import com.optimove.android.main.tools.opti_logger.LogLevel;
 import com.optimove.android.optimobile.DeferredDeepLinkHandlerInterface;
 import com.optimove.android.optimobile.InternalSdkEmbeddingApi;
 import com.optimove.android.optimobile.UrlBuilder;
-import com.optimove.android.R;
 
 import org.json.JSONObject;
 
@@ -46,8 +44,10 @@ public final class OptimoveConfig {
 
     @DrawableRes
     private int notificationSmallIconId;
-    private InAppConsentStrategy inAppConsentStrategy;
     private int sessionIdleTimeoutSeconds;
+
+    private InAppConsentStrategy inAppConsentStrategy;
+    private InAppDisplayMode inAppDisplayMode;
 
     private JSONObject runtimeInfo;
     private JSONObject sdkInfo;
@@ -61,6 +61,11 @@ public final class OptimoveConfig {
     public enum InAppConsentStrategy {
         AUTO_ENROLL,
         EXPLICIT_BY_USER
+    }
+
+    public enum InAppDisplayMode {
+        AUTOMATIC,
+        PAUSED
     }
 
     // Private constructor to discourage not using the Builder.
@@ -109,6 +114,10 @@ public final class OptimoveConfig {
 
     private void setInAppConsentStrategy(InAppConsentStrategy strategy) {
         this.inAppConsentStrategy = strategy;
+    }
+
+    private void setInAppDisplayMode(@NonNull InAppDisplayMode mode) {
+        this.inAppDisplayMode = mode;
     }
 
     private void setCname(@Nullable URL deepLinkCname) {
@@ -171,6 +180,9 @@ public final class OptimoveConfig {
         return inAppConsentStrategy;
     }
 
+    public @NonNull
+    InAppDisplayMode getInAppDisplayMode() { return inAppDisplayMode; }
+
     public @Nullable
     URL getDeepLinkCname() {
         return this.deepLinkCname;
@@ -209,8 +221,10 @@ public final class OptimoveConfig {
 
         @DrawableRes
         private int notificationSmallIconDrawableId = OptimoveConfig.DEFAULT_NOTIFICATION_ICON_ID;
-        private InAppConsentStrategy consentStrategy = null;
         private int sessionIdleTimeoutSeconds = OptimoveConfig.DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS;
+
+        private InAppConsentStrategy consentStrategy = null;
+        private InAppDisplayMode inAppDisplayMode = null;
 
         private JSONObject runtimeInfo;
         private JSONObject sdkInfo;
@@ -283,9 +297,14 @@ public final class OptimoveConfig {
             return this;
         }
 
-        public Builder enableInAppMessaging(InAppConsentStrategy strategy) {
+        public Builder enableInAppMessaging(@NonNull InAppConsentStrategy strategy, @NonNull InAppDisplayMode defaultDisplayMode) {
             this.consentStrategy = strategy;
+            this.inAppDisplayMode = defaultDisplayMode;
             return this;
+        }
+
+        public Builder enableInAppMessaging(InAppConsentStrategy strategy) {
+            return enableInAppMessaging(strategy, InAppDisplayMode.AUTOMATIC);
         }
 
         public Builder enableDeepLinking(@NonNull String cname, DeferredDeepLinkHandlerInterface handler) {
@@ -373,6 +392,7 @@ public final class OptimoveConfig {
             newConfig.setBaseUrlMap(this.baseUrlMap);
 
             newConfig.setInAppConsentStrategy(consentStrategy);
+            newConfig.setInAppDisplayMode(inAppDisplayMode);
 
             newConfig.setCname(this.deepLinkCname);
             newConfig.setDeferredDeepLinkHandler(this.deferredDeepLinkHandler);

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
@@ -39,7 +39,6 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
 
     @Override
     public void appEnteredForeground() {
-        Log.d("INAPP", "APP ENTERED FG");
         if (!OptimoveInApp.getInstance().isInAppEnabled()) {
             return;
         }
@@ -49,7 +48,6 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
 
     @Override
     public void activityAvailable(@NonNull Activity activity) {
-        Log.d("INAPP", "ACTIVITY AVAILABLE");
         if (!OptimoveInApp.getInstance().isInAppEnabled()) {
             return;
         }
@@ -145,7 +143,6 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
 
     @UiThread
     private void presentMessageToClient() {
-        Log.d("INAPP", "INAPP PRESENT TO CLIENT");
         InAppMessage currentMessage = getCurrentMessage();
 
         if (null == currentMessage || getDisplayMode() == OptimoveConfig.InAppDisplayMode.PAUSED) {

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessageService.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessageService.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import  com.optimove.android.BuildConfig;
+import com.optimove.android.OptimoveConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -235,6 +236,10 @@ class InAppMessageService {
     }
 
     static OptimoveInApp.InboxMessagePresentationResult presentMessage(Context context, InAppInboxItem item) {
+        if (OptimoveInApp.presenter.getDisplayMode() == OptimoveConfig.InAppDisplayMode.PAUSED) {
+            return OptimoveInApp.InboxMessagePresentationResult.PAUSED;
+        }
+
         Callable<InAppMessage> task = new InAppContract.ReadInAppInboxMessageCallable(context, item.getId());
         final Future<InAppMessage> future = Optimobile.executorService.submit(task);
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveInApp.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveInApp.java
@@ -25,7 +25,8 @@ public class OptimoveInApp {
     public enum InboxMessagePresentationResult {
         FAILED,
         FAILED_EXPIRED,
-        PRESENTED
+        PRESENTED,
+        PAUSED
     }
 
     public interface InAppInboxUpdatedHandler extends Runnable {
@@ -160,6 +161,10 @@ public class OptimoveInApp {
         this.inAppDeepLinkHandler = handler;
     }
 
+    public void setDisplayMode(OptimoveConfig.InAppDisplayMode mode) {
+        presenter.setDisplayMode(mode);
+    }
+
 
     //==============================================================================================
     //-- Internal Helpers
@@ -180,7 +185,7 @@ public class OptimoveInApp {
             shared.clearLastSyncTime(application);
         }
 
-        presenter = new InAppMessagePresenter(application);
+        presenter = new InAppMessagePresenter(application, currentConfig.getInAppDisplayMode());
 
         shared.toggleInAppMessageMonitoring(inAppEnabled);
     }


### PR DESCRIPTION
### Description of Changes

Add an in-app display mode configuration that allows pausing display of in-app messages.

All existing in-app behaviours such as queueing are performed as normal whilst display is paused, only the presentation of the message view itself is prevented.

This is exposed as a 'default' configuration option and a new API to set the behaviour at runtime.

When display was previously paused and then enabled again, any pending messages in the queue should be presented.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [x] CHANGELOG.md
- [x] gradle.properties
- [ ] ~add links to newly created wiki pages to readme~
- [ ] ~Update major version numbers in wiki (basic integration + push guides)~

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [x] Register for push
- [x] Opt-in for In-App
- [x] Send test push
- [x] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
