### PR TITLE
201381 - setting credentials late [1/3]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ Bump versions in:
 
 - [ ] CHANGELOG.md
 - [ ] gradle.properties
+- [ ] add links to newly created wiki pages to readme
 
 ### Integration tests
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ Bump versions in:
 - [ ] CHANGELOG.md
 - [ ] gradle.properties
 - [ ] add links to newly created wiki pages to readme
+- [ ] Update major version numbers in wiki (basic integration + push guides)
 
 ### Integration tests
 

--- a/OptimoveSDK/app/build.gradle
+++ b/OptimoveSDK/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 31
     buildToolsVersion '30.0.3'
     defaultConfig {
-        applicationId "com.optimove.sdk.optimovemobilesdk"
+        applicationId "com.optimove.android.optimovemobilesdk"
         minSdkVersion 21
         targetSdkVersion 31
         versionCode Integer.parseInt("$sdk_version_code")
@@ -34,9 +34,9 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     testImplementation 'junit:junit:4.12'
 
-    // implementation platform('com.google.firebase:firebase-bom:28.2.0')
-    // implementation 'com.google.firebase:firebase-messaging'
+     implementation platform('com.google.firebase:firebase-bom:28.2.0')
+     implementation 'com.google.firebase:firebase-messaging'
 }
 
-//apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.gms.google-services'
 //apply plugin: 'com.huawei.agconnect'

--- a/OptimoveSDK/app/build.gradle
+++ b/OptimoveSDK/app/build.gradle
@@ -34,9 +34,9 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     testImplementation 'junit:junit:4.12'
 
-     implementation platform('com.google.firebase:firebase-bom:28.2.0')
-     implementation 'com.google.firebase:firebase-messaging'
+    // implementation platform('com.google.firebase:firebase-bom:28.2.0')
+    // implementation 'com.google.firebase:firebase-messaging'
 }
 
-apply plugin: 'com.google.gms.google-services'
+//apply plugin: 'com.google.gms.google-services'
 //apply plugin: 'com.huawei.agconnect'

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
@@ -140,21 +140,15 @@ public void setCredentials(View view) {
   }
 
   private void setCredInitialisationType() {
-    RadioButton radioBtnToEnable = null;
-    if (Optimove.getConfig().usesDelayedOptimoveConfiguration() || Optimove.getConfig().usesDelayedOptimobileConfiguration()){
-      radioBtnToEnable = (RadioButton) findViewById(R.id.partialInitRadio);
-    }
-    else{
-      radioBtnToEnable = (RadioButton) findViewById(R.id.completeInitRadio);
-      Button setCredsBtn = (Button) findViewById(R.id.submitCredentialsBtn);
-      setCredsBtn.setEnabled(false);
-
+    if (!Optimove.getConfig().usesDelayedOptimoveConfiguration() && !Optimove.getConfig().usesDelayedOptimobileConfiguration()){
       EditText optimoveCredInput = findViewById(R.id.optimoveCredInput);
-      optimoveCredInput.setEnabled(false);
+      optimoveCredInput.setVisibility(View.GONE);
 
       EditText optimobileCredInput = findViewById(R.id.optimobileCredInput);
-      optimobileCredInput.setEnabled(false);
+      optimobileCredInput.setVisibility(View.GONE);
+
+      Button setCredsBtn = (Button) findViewById(R.id.submitCredentialsBtn);
+      setCredsBtn.setVisibility(View.GONE);
     }
-    radioBtnToEnable.setChecked(true);
   }
 }

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
@@ -6,7 +6,9 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.Button;
 import android.widget.EditText;
+import android.widget.RadioButton;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -32,10 +34,14 @@ public class MainActivity extends AppCompatActivity {
     setContentView(R.layout.activity_main);
     outputTv = findViewById(R.id.userIdTextView);
 
+    this.setCredInitialisationType();
+
     if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
       ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, WRITE_EXTERNAL_PERMISSION_REQUEST_CODE);
     }
   }
+
+
 
   @Override
   protected void onNewIntent(Intent intent) {
@@ -80,6 +86,36 @@ public class MainActivity extends AppCompatActivity {
     }
   }
 
+public void setCredentials(View view) {
+     EditText optimoveCreds  = findViewById(R.id.optimoveCredInput);
+     EditText optimobileCreds = findViewById(R.id.optimobileCredInput);
+
+     String optimoveCredentials = optimoveCreds.getText().toString();
+     String optimobileCredentials = optimobileCreds.getText().toString();
+
+     if (optimoveCredentials.isEmpty() && optimobileCredentials.isEmpty()){
+       return;
+     }
+
+     if (optimoveCredentials.isEmpty()){
+       optimoveCredentials = null;
+     }
+
+      if (optimobileCredentials.isEmpty()){
+        optimobileCredentials = null;
+      }
+
+
+
+
+      Optimove.setCredentials(optimoveCredentials, optimobileCredentials);
+
+      outputTv.setText("Credentials submitted");
+      Button setCredsBtn = (Button) findViewById(R.id.submitCredentialsBtn);
+      setCredsBtn.setEnabled(false);
+
+  }
+
   public void runFromWorker(Runnable runnable) {
     new Thread(runnable).start();
   }
@@ -101,5 +137,24 @@ public class MainActivity extends AppCompatActivity {
       result.put("number_param", 42);
       return result;
     }
+  }
+
+  private void setCredInitialisationType() {
+    RadioButton radioBtnToEnable = null;
+    if (Optimove.getConfig().usesDelayedOptimoveConfiguration() || Optimove.getConfig().usesDelayedOptimobileConfiguration()){
+      radioBtnToEnable = (RadioButton) findViewById(R.id.partialInitRadio);
+    }
+    else{
+      radioBtnToEnable = (RadioButton) findViewById(R.id.completeInitRadio);
+      Button setCredsBtn = (Button) findViewById(R.id.submitCredentialsBtn);
+      setCredsBtn.setEnabled(false);
+
+      EditText optimoveCredInput = findViewById(R.id.optimoveCredInput);
+      optimoveCredInput.setEnabled(false);
+
+      EditText optimobileCredInput = findViewById(R.id.optimobileCredInput);
+      optimobileCredInput.setEnabled(false);
+    }
+    radioBtnToEnable.setChecked(true);
   }
 }

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
@@ -34,7 +34,7 @@ public class MainActivity extends AppCompatActivity {
     setContentView(R.layout.activity_main);
     outputTv = findViewById(R.id.userIdTextView);
 
-    this.setCredInitialisationType();
+    this.hideIrrelevantInputs();
 
     if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
       ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, WRITE_EXTERNAL_PERMISSION_REQUEST_CODE);
@@ -139,16 +139,19 @@ public void setCredentials(View view) {
     }
   }
 
-  private void setCredInitialisationType() {
-    if (!Optimove.getConfig().usesDelayedOptimoveConfiguration() && !Optimove.getConfig().usesDelayedOptimobileConfiguration()){
-      EditText optimoveCredInput = findViewById(R.id.optimoveCredInput);
-      optimoveCredInput.setVisibility(View.GONE);
-
-      EditText optimobileCredInput = findViewById(R.id.optimobileCredInput);
-      optimobileCredInput.setVisibility(View.GONE);
-
-      Button setCredsBtn = (Button) findViewById(R.id.submitCredentialsBtn);
-      setCredsBtn.setVisibility(View.GONE);
+  private void hideIrrelevantInputs() {
+    if (Optimove.getConfig().usesDelayedConfiguration()) {
+      return;
     }
+
+    EditText optimoveCredInput = findViewById(R.id.optimoveCredInput);
+    optimoveCredInput.setVisibility(View.GONE);
+
+    EditText optimobileCredInput = findViewById(R.id.optimobileCredInput);
+    optimobileCredInput.setVisibility(View.GONE);
+
+    Button setCredsBtn = (Button) findViewById(R.id.submitCredentialsBtn);
+    setCredsBtn.setVisibility(View.GONE);
+
   }
 }

--- a/OptimoveSDK/app/src/main/res/layout/activity_main.xml
+++ b/OptimoveSDK/app/src/main/res/layout/activity_main.xml
@@ -110,7 +110,6 @@
                 android:id="@+id/optimoveCredInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="20dp"
                 android:ems="10"
                 android:hint="Optimove credentials"
                 android:inputType="textPersonName" />
@@ -119,7 +118,6 @@
                 android:id="@+id/optimobileCredInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="20dp"
                 android:ems="10"
                 android:hint="Optimobile credentials"
                 android:inputType="textPersonName" />
@@ -128,7 +126,6 @@
                 android:id="@+id/submitCredentialsBtn"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="20dp"
                 android:onClick="setCredentials"
                 android:text="Submit credentials" />
 

--- a/OptimoveSDK/app/src/main/res/layout/activity_main.xml
+++ b/OptimoveSDK/app/src/main/res/layout/activity_main.xml
@@ -106,26 +106,6 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <RadioGroup
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clickable="false">
-
-                <RadioButton
-                    android:id="@+id/completeInitRadio"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:enabled="false"
-                    android:text="Complete init (have credentials immediately)" />
-
-                <RadioButton
-                    android:id="@+id/partialInitRadio"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:enabled="false"
-                    android:text="Partial init (creds decided later)" />
-            </RadioGroup>
-
             <EditText
                 android:id="@+id/optimoveCredInput"
                 android:layout_width="match_parent"

--- a/OptimoveSDK/app/src/main/res/layout/activity_main.xml
+++ b/OptimoveSDK/app/src/main/res/layout/activity_main.xml
@@ -1,82 +1,167 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_gravity="center"
-    android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/userIdTextView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:gravity="center"
-        android:text="Welcome to the Optimove Android SDK test"
-        android:textSize="16sp"/>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <LinearLayout
+
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="horizontal">
+        android:layout_height="match_parent"
+        android:layout_gravity="top"
+        android:orientation="vertical">
 
-        <EditText
-            android:id="@+id/userIdInput"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_gravity="start|center_vertical"
-            android:layout_weight="1"
-            android:hint="Enter userId"
-            android:textSize="18sp"/>
 
-        <EditText
-            android:id="@+id/userEmailInput"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_gravity="start|center_vertical"
+        <TextView
+            android:id="@+id/userIdTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:gravity="center"
+            android:text="Welcome to the Optimove Android SDK test"
+            android:textSize="16sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:orientation="horizontal">
+
+            <EditText
+                android:id="@+id/userIdInput"
+                android:layout_width="0dp"
+                android:layout_height="50dp"
+                android:layout_gravity="start|center_vertical"
+                android:layout_weight="1"
+                android:hint="Enter userId"
+                android:textSize="18sp" />
+
+            <EditText
+                android:id="@+id/userEmailInput"
+                android:layout_width="0dp"
+                android:layout_height="50dp"
+                android:layout_gravity="start|center_vertical"
+                android:layout_weight="1"
+                android:hint="Enter Email"
+                android:inputType="textEmailAddress"
+                android:textSize="18sp" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/updateUserIdButton"
+            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="70dp"
+            android:layout_margin="16dp"
+            android:layout_weight="0"
+            android:background="#7D7D7D"
+            android:gravity="center"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:onClick="updateUserId"
+            android:text="Update userId"
+            android:textAllCaps="false"
+            android:textColor="#FFFFFF" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/resetTokenButton"
+                style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                android:layout_width="0dp"
+                android:layout_height="70dp"
+                android:layout_margin="16dp"
+                android:layout_weight="1"
+                android:background="#7D7D7D"
+                android:gravity="center"
+                android:onClick="resetToken"
+                android:text="Reset Token"
+                android:textAllCaps="false"
+                android:textColor="#FFFFFF" />
+
+            <Button
+                android:id="@+id/customerReportEventButton"
+                style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                android:layout_width="0dp"
+                android:layout_height="70dp"
+                android:layout_margin="16dp"
+                android:layout_weight="1"
+                android:background="#7D7D7D"
+                android:gravity="center"
+                android:onClick="reportEvent"
+                android:text="Report As Customer Event"
+                android:textAllCaps="false"
+                android:textColor="#FFFFFF" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clickable="false">
+
+                <RadioButton
+                    android:id="@+id/completeInitRadio"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:enabled="false"
+                    android:text="Complete init (have credentials immediately)" />
+
+                <RadioButton
+                    android:id="@+id/partialInitRadio"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:enabled="false"
+                    android:text="Partial init (creds decided later)" />
+            </RadioGroup>
+
+            <EditText
+                android:id="@+id/optimoveCredInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:ems="10"
+                android:hint="Optimove credentials"
+                android:inputType="textPersonName" />
+
+            <EditText
+                android:id="@+id/optimobileCredInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:ems="10"
+                android:hint="Optimobile credentials"
+                android:inputType="textPersonName" />
+
+            <Button
+                android:id="@+id/submitCredentialsBtn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:onClick="setCredentials"
+                android:text="Submit credentials" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:hint="Enter Email"
-            android:inputType="textEmailAddress"
-            android:textSize="18sp"/>
+            android:orientation="vertical">
+
+        </LinearLayout>
+
 
     </LinearLayout>
-
-    <Button
-        android:id="@+id/updateUserIdButton"
-        style="@style/Widget.AppCompat.Button.Borderless.Colored"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_margin="16dp"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:onClick="updateUserId"
-        android:text="Update userId"
-        android:textAllCaps="false"/>
-
-    <Button
-        android:id="@+id/customerReportEventButton"
-        style="@style/Widget.AppCompat.Button.Borderless.Colored"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_margin="16dp"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:onClick="reportEvent"
-        android:text="Report As Customer Event"
-        android:textAllCaps="false"/>
-
-    <Button
-        android:id="@+id/resetTokenButton"
-        style="@style/Widget.AppCompat.Button.Borderless.Colored"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_margin="16dp"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:onClick="resetToken"
-        android:text="Reset Token"
-        android:textAllCaps="false"/>
-
-
-</LinearLayout>
+</ScrollView>

--- a/OptimoveSDK/build.gradle
+++ b/OptimoveSDK/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'com.google.gms:google-services:4.3.10'
     }
 }
 

--- a/OptimoveSDK/build.gradle
+++ b/OptimoveSDK/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.google.gms:google-services:4.3.10'
     }
 }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
@@ -176,13 +176,12 @@ final public class Optimove {
         }
 
         currentConfig.setCredentials(optimoveCredentials, optimobileCredentials);
-        if (optimobileCredentials != null){
+        if (optimobileCredentials != null && currentConfig.usesDelayedOptimobileConfiguration()){
             Optimobile.completeDelayedConfiguration(currentConfig);
         }
 
-        if (currentConfig.isOptimoveConfigured()){
-            Application application = (Application) shared.getApplicationContext();
-            Optimove.finishInitialization(application, currentConfig);
+        if (optimoveCredentials != null && currentConfig.usesDelayedOptimoveConfiguration()){
+            Optimove.finishInitialization((Application) shared.getApplicationContext(), currentConfig);
         }
     }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
@@ -63,7 +63,7 @@ final public class Optimove {
     private final UserInfo userInfo;
     private final SharedPreferences localConfigKeysPreferences;
     private final EventHandlerProvider eventHandlerProvider;
-    private final OptimoveLifecycleEventGenerator optimoveLifecycleEventGenerator;
+    private OptimoveLifecycleEventGenerator optimoveLifecycleEventGenerator;
     private final DeviceInfoProvider deviceInfoProvider;
     private final AtomicBoolean configSet;
     private final LifecycleObserver lifecycleObserver;
@@ -81,19 +81,6 @@ final public class Optimove {
         this.context = context;
         this.userInfo = UserInfo.newInstance(context);
 
-        if (!config.isOptimoveConfigured()) {
-            //if optimove credentials not set, optimove API should fail early
-            coreSharedPreferences = null;
-            localConfigKeysPreferences = null;
-            eventHandlerProvider = null;
-            optimoveLifecycleEventGenerator = null;
-            deviceInfoProvider = null;
-            configSet = null;
-            lifecycleObserver = null;
-
-            return;
-        }
-
         this.coreSharedPreferences = context.getSharedPreferences(TenantConfigsKeys.CORE_SP_FILE,
                 Context.MODE_PRIVATE);
         this.deviceInfoProvider = new DeviceInfoProvider(context);
@@ -109,8 +96,7 @@ final public class Optimove {
                 .lifecycleObserver(lifecycleObserver)
                 .context(context)
                 .build());
-        this.optimoveLifecycleEventGenerator = new OptimoveLifecycleEventGenerator(eventHandlerProvider, userInfo,
-                context.getPackageName());
+
         this.configSet = new AtomicBoolean(false);
     }
 
@@ -144,25 +130,59 @@ final public class Optimove {
         }
 
         if (config.isOptimoveConfigured()) {
-            if (config.getCustomMinLogLevel() != null) {
-                OptiLoggerStreamsContainer.setMinLogLevelToShow(config.getCustomMinLogLevel());
-            }
+            Optimove.finishInitialization(application, config);
+        }
+    }
 
-            OptiLoggerStreamsContainer.initializeLogger(application.getApplicationContext());
+    private static void finishInitialization(@NonNull Application application, @NonNull OptimoveConfig config){
+        shared.optimoveLifecycleEventGenerator = new OptimoveLifecycleEventGenerator(shared.eventHandlerProvider, shared.userInfo,
+                application.getPackageName());
 
-            Runnable initCommand = () -> {
-                OptiLoggerStreamsContainer.debug("Optimove.initialize() is starting");
-                shared.lifecycleObserver.addActivityStoppedListener(shared.optimoveLifecycleEventGenerator);
-                shared.lifecycleObserver.addActivityStartedListener(shared.optimoveLifecycleEventGenerator);
-                application.registerActivityLifecycleCallbacks(shared.lifecycleObserver);
-                shared.fetchConfigs();
-            };
-            if (!OptiUtils.isRunningOnMainThread()) {
-                OptiLoggerStreamsContainer.debug("Optimove.initialize() was called from a worker thread, moving call to main thread");
-                OptiUtils.runOnMainThread(initCommand);
-            } else {
-                initCommand.run();
-            }
+        TenantInfo newTenantInfo = new TenantInfo(config.getOptimoveToken(), config.getConfigFileName());
+        TenantInfo localTenantInfo = shared.retrieveLocalTenantInfo();
+        if (localTenantInfo != null) {
+            // Now merge the local with the new. NOTE: the new does not contain a tenant ID while the local must contain tenant ID otherwise it will be null
+            newTenantInfo.setTenantId(localTenantInfo.getTenantId());
+            shared.setAndStoreTenantInfo(newTenantInfo);
+        } else {
+            // No point in storing the tenant info as it is not yet valid (tenantId == -1). It will be stored once the configurations are fetched
+            shared.tenantInfo = newTenantInfo;
+        }
+
+        if (config.getCustomMinLogLevel() != null) {
+            OptiLoggerStreamsContainer.setMinLogLevelToShow(config.getCustomMinLogLevel());
+        }
+
+        OptiLoggerStreamsContainer.initializeLogger(application.getApplicationContext());
+
+        Runnable initCommand = () -> {
+            OptiLoggerStreamsContainer.debug("Optimove.initialize() is starting");
+            shared.lifecycleObserver.addActivityStoppedListener(shared.optimoveLifecycleEventGenerator);
+            shared.lifecycleObserver.addActivityStartedListener(shared.optimoveLifecycleEventGenerator);
+            application.registerActivityLifecycleCallbacks(shared.lifecycleObserver);
+            shared.fetchConfigs();
+        };
+        if (!OptiUtils.isRunningOnMainThread()) {
+            OptiLoggerStreamsContainer.debug("Optimove.initialize() was called from a worker thread, moving call to main thread");
+            OptiUtils.runOnMainThread(initCommand);
+        } else {
+            initCommand.run();
+        }
+    }
+
+    public static void setCredentials(@Nullable String optimoveCredentials, @Nullable String optimobileCredentials) {
+        if (!currentConfig.usesDelayedConfiguration()){
+            throw new IllegalStateException("Cannot set credentials as delayed configuration is not enabled");
+        }
+
+        currentConfig.setCredentials(optimoveCredentials, optimobileCredentials);
+        if (optimobileCredentials != null){
+            Optimobile.completeDelayedConfiguration(currentConfig);
+        }
+
+        if (currentConfig.isOptimoveConfigured()){
+            Application application = (Application) shared.getApplicationContext();
+            Optimove.finishInitialization(application, currentConfig);
         }
     }
 
@@ -256,21 +276,6 @@ final public class Optimove {
             return;
         }
         shared = new Optimove(context, config);
-
-        if (!config.isOptimoveConfigured()) {
-            return;
-        }
-
-        TenantInfo newTenantInfo = new TenantInfo(config.getOptimoveToken(), config.getConfigFileName());
-        TenantInfo localTenantInfo = shared.retrieveLocalTenantInfo();
-        if (localTenantInfo != null) {
-            // Now merge the local with the new. NOTE: the new does not contain a tenant ID while the local must contain tenant ID otherwise it will be null
-            newTenantInfo.setTenantId(localTenantInfo.getTenantId());
-            shared.setAndStoreTenantInfo(newTenantInfo);
-        } else {
-            // No point in storing the tenant info as it is not yet valid (tenantId == -1). It will be stored once the configurations are fetched
-            shared.tenantInfo = newTenantInfo;
-        }
     }
 
     //==============================================================================================

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -73,9 +73,19 @@ public final class OptimoveConfig {
     }
 
     public enum Region {
-        EU2,
-        US1,
-        UK1
+        EU("eu-central-2"),
+        US("us-east-1"),
+        DEV("uk-1");
+        private final String region;
+
+        Region(String region) {
+            this.region = region;
+        }
+
+        @NonNull
+        public String toString() {
+            return region;
+        }
     }
 
     public enum FeatureSet {
@@ -308,19 +318,7 @@ public final class OptimoveConfig {
         private @Nullable LogLevel minLogLevel;
 
         public Builder(@NonNull Region region, @NonNull FeatureSet featureSet) {
-            switch (region) {
-                case EU2:
-                    this.region = "eu-central-2";
-                    break;
-                case US1:
-                    this.region = "us-east-1";
-                    break;
-                case UK1:
-                    this.region ="uk-1";
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown region " + region);
-            }
+            this.region = region.toString();
             this.baseUrlMap = UrlBuilder.defaultMapping(this.region);
             this.featureSet = featureSet;
             this.delayedInitialisation = true;

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -295,7 +295,7 @@ public final class OptimoveConfig {
 
         private @Nullable LogLevel minLogLevel;
 
-        public Builder(Region region, @NonNull PartialInitType partialInitType) {
+        public Builder(@NonNull Region region, @NonNull PartialInitType partialInitType) {
             switch (region) {
                 case EU2:
                     this.region = "eu-central-2";

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -58,6 +58,8 @@ public final class OptimoveConfig {
 
     private @Nullable LogLevel minLogLevel;
 
+    private boolean delayedCredentials = false;
+
     public enum InAppConsentStrategy {
         AUTO_ENROLL,
         EXPLICIT_BY_USER
@@ -66,6 +68,12 @@ public final class OptimoveConfig {
     public enum InAppDisplayMode {
         AUTOMATIC,
         PAUSED
+    }
+
+    public enum Region {
+        EU2,
+        US1,
+        UK1
     }
 
     // Private constructor to discourage not using the Builder.
@@ -131,6 +139,8 @@ public final class OptimoveConfig {
     private void setMinLogLevel(@Nullable LogLevel minLogLevel){
         this.minLogLevel = minLogLevel;
     }
+
+    private void setDelayedCredentials(boolean delayed){ this.delayedCredentials = delayed; }
 
     @Nullable
     public String getRegion() {
@@ -204,6 +214,10 @@ public final class OptimoveConfig {
         return this.minLogLevel;
     }
 
+    public boolean usesDelayedConfiguration(){
+        return this.delayedCredentials;
+    }
+
     /**
      * Config builder for the Optimobile client
      */
@@ -235,6 +249,26 @@ public final class OptimoveConfig {
         private DeferredDeepLinkHandlerInterface deferredDeepLinkHandler;
 
         private @Nullable LogLevel minLogLevel;
+
+        private boolean delayedCredentials = false;
+
+        public Builder(Region region) {
+            switch (region) {
+                case EU2:
+                    this.region = "eu-central-2";
+                    break;
+                case US1:
+                    this.region = "us-east-1";
+                    break;
+                case UK1:
+                    this.region ="uk-1";
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown region" + region);
+            }
+            this.baseUrlMap = UrlBuilder.defaultMapping(this.region);
+            this.delayedCredentials = true;
+        }
 
         public Builder(@Nullable String optimoveCredentials, @Nullable String optimobileCredentials) {
             if (optimoveCredentials == null && optimobileCredentials == null) {
@@ -398,6 +432,8 @@ public final class OptimoveConfig {
             newConfig.setDeferredDeepLinkHandler(this.deferredDeepLinkHandler);
 
             newConfig.setMinLogLevel(this.minLogLevel);
+
+            newConfig.setDelayedCredentials(delayedCredentials);
 
             return newConfig;
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -58,7 +58,7 @@ public final class OptimoveConfig {
 
     private @Nullable LogLevel minLogLevel;
 
-    private @Nullable PartialInitType partialInitType;
+    private @Nullable FeatureSet featureSet;
 
     public enum InAppConsentStrategy {
         AUTO_ENROLL,
@@ -76,7 +76,7 @@ public final class OptimoveConfig {
         UK1
     }
 
-    public enum PartialInitType {
+    public enum FeatureSet {
         OPTIMOBILE_ONLY,
         OPTIMOVE_ONLY,
         ALL
@@ -180,7 +180,7 @@ public final class OptimoveConfig {
         return new JSONArray(new String(data, StandardCharsets.UTF_8));
     }
 
-    private void setPartialInitType(@Nullable PartialInitType partialInitType){ this.partialInitType = partialInitType; }
+    private void setFeatureSet(@Nullable FeatureSet featureSet){ this.featureSet = featureSet; }
 
     @Nullable
     public String getRegion() {
@@ -256,11 +256,11 @@ public final class OptimoveConfig {
     }
 
     public boolean usesDelayedOptimobileConfiguration(){
-        return this.partialInitType == PartialInitType.OPTIMOBILE_ONLY || this.partialInitType == PartialInitType.ALL;
+        return this.featureSet == FeatureSet.OPTIMOBILE_ONLY || this.featureSet == FeatureSet.ALL;
     }
 
     public boolean usesDelayedOptimoveConfiguration(){
-        return this.partialInitType == PartialInitType.OPTIMOVE_ONLY || this.partialInitType == PartialInitType.ALL;
+        return this.featureSet == FeatureSet.OPTIMOVE_ONLY || this.featureSet == FeatureSet.ALL;
     }
 
     public boolean usesDelayedConfiguration(){
@@ -275,7 +275,7 @@ public final class OptimoveConfig {
         String region;
         private @Nullable String optimoveCredentials;
         private @Nullable String optimobileCredentials;
-        private  @Nullable PartialInitType partialInitType = null;
+        private  @Nullable FeatureSet featureSet = null;
 
         @DrawableRes
         private int notificationSmallIconDrawableId = OptimoveConfig.DEFAULT_NOTIFICATION_ICON_ID;
@@ -295,7 +295,7 @@ public final class OptimoveConfig {
 
         private @Nullable LogLevel minLogLevel;
 
-        public Builder(@NonNull Region region, @NonNull PartialInitType partialInitType) {
+        public Builder(@NonNull Region region, @NonNull FeatureSet featureSet) {
             switch (region) {
                 case EU2:
                     this.region = "eu-central-2";
@@ -310,7 +310,7 @@ public final class OptimoveConfig {
                     throw new IllegalArgumentException("Unknown region " + region);
             }
             this.baseUrlMap = UrlBuilder.defaultMapping(this.region);
-            this.partialInitType = partialInitType;
+            this.featureSet = featureSet;
         }
 
         public Builder(@Nullable String optimoveCredentials, @Nullable String optimobileCredentials) {
@@ -412,8 +412,8 @@ public final class OptimoveConfig {
 
         public OptimoveConfig build() {
             OptimoveConfig newConfig = new OptimoveConfig();
-            newConfig.setPartialInitType(this.partialInitType);
-            if (partialInitType == null){
+            newConfig.setFeatureSet(this.featureSet);
+            if (featureSet == null){
                 newConfig.setCredentials(this.optimoveCredentials, this.optimobileCredentials);
             }
             else{

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -78,7 +78,8 @@ public final class OptimoveConfig {
 
     public enum PartialInitType {
         OPTIMOBILE_ONLY,
-        //TODO: support OPTIMOVE_ONLY and ALL
+        OPTIMOVE_ONLY,
+        ALL
     }
 
     // Private constructor to discourage not using the Builder.
@@ -255,12 +256,11 @@ public final class OptimoveConfig {
     }
 
     public boolean usesDelayedOptimobileConfiguration(){
-        return this.partialInitType == PartialInitType.OPTIMOBILE_ONLY;
+        return this.partialInitType == PartialInitType.OPTIMOBILE_ONLY || this.partialInitType == PartialInitType.ALL;
     }
 
     public boolean usesDelayedOptimoveConfiguration(){
-        //TODO: cache things in optimove as well
-        return false;
+        return this.partialInitType == PartialInitType.OPTIMOVE_ONLY || this.partialInitType == PartialInitType.ALL;
     }
 
     public boolean usesDelayedConfiguration(){

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsContract.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsContract.java
@@ -115,6 +115,11 @@ final class AnalyticsContract {
                 return;
             }
 
+            //TODO: create wrapper http client and move this check there?
+            if (Optimobile.authHeader == null) {
+                return;
+            }
+
             if (immediateFlush) {
                 AnalyticsUploadHelper helper = new AnalyticsUploadHelper();
                 AnalyticsUploadHelper.Result result = helper.flushEvents(mContext);

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/DeferredDeepLinkHelper.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/DeferredDeepLinkHelper.java
@@ -223,6 +223,10 @@ public class DeferredDeepLinkHelper {
     }
 
     private void handleDeepLink(Context context, URL url, boolean wasDeferred) {
+        if (Optimobile.authHeader == null) {
+            //TODO: support for delayed credentials for deep links
+            throw new RuntimeException("Not supported");
+        }
         OkHttpClient httpClient = Optimobile.getHttpClient();
 
         String slug = Uri.encode(url.getPath().replaceAll("/$|^/", ""));
@@ -335,6 +339,10 @@ public class DeferredDeepLinkHelper {
     }
 
     private void handleFingerprintComponents(Context context, JSONObject components) {
+        if (Optimobile.authHeader == null) {
+            //TODO: support for delayed credentials for deep links
+            throw new RuntimeException("Not supported");
+        }
         String encodedComponents = Base64.encodeToString(components.toString().getBytes(), Base64.NO_WRAP);
         String requestUrl = Optimobile.urlBuilder.urlForService(UrlBuilder.Service.DDL, "/v1/deeplinks/_taps?fingerprint=" + encodedComponents);
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
@@ -24,6 +24,11 @@ class InAppRequestService {
     private static final String TAG = InAppRequestService.class.getName();
 
     static List<InAppMessage> readInAppMessages(Context c, Date lastSyncTime) {
+        //TODO: create wrapper http client and move this check there?
+        if (Optimobile.authHeader == null) {
+            return null;
+        }
+
         OkHttpClient httpClient;
         String userIdentifier = Optimobile.getCurrentUserIdentifier(c);
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -83,7 +83,7 @@ public final class Optimobile {
      * @param config
      */
     public static synchronized void initialize(final Application application, OptimoveConfig config, String initialVisitorId, @Nullable String customerId) {
-        if (!config.isOptimobileConfigured()){
+        if (!config.isOptimobileConfigured() && !config.usesDelayedConfiguration()){
             throw new UninitializedException();
         }
 
@@ -94,7 +94,7 @@ public final class Optimobile {
 
         installId = initialVisitorId;
 
-        authHeader = buildBasicAuthHeader(config.getApiKey(), config.getSecretKey());
+        authHeader = config.usesDelayedConfiguration() ? null : buildBasicAuthHeader(config.getApiKey(), config.getSecretKey());
 
         urlBuilder  = new UrlBuilder(config.getBaseUrlMap());
         httpClient = buildOkHttpClient();

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -83,7 +83,7 @@ public final class Optimobile {
      * @param config
      */
     public static synchronized void initialize(final Application application, OptimoveConfig config, String initialVisitorId, @Nullable String customerId) {
-        if (!config.isOptimobileConfigured() && !config.usesDelayedConfiguration()){
+        if (!config.isOptimobileConfigured()){
             throw new UninitializedException();
         }
 
@@ -94,7 +94,7 @@ public final class Optimobile {
 
         installId = initialVisitorId;
 
-        authHeader = config.usesDelayedConfiguration() ? null : buildBasicAuthHeader(config.getApiKey(), config.getSecretKey());
+        authHeader = config.usesDelayedOptimobileConfiguration() ? null : buildBasicAuthHeader(config.getApiKey(), config.getSecretKey());
 
         urlBuilder  = new UrlBuilder(config.getBaseUrlMap());
         httpClient = buildOkHttpClient();
@@ -116,6 +116,18 @@ public final class Optimobile {
         executorService.submit(statsTask);
 
         maybeMigrateUserAssociation(application, customerId);
+    }
+
+    public static synchronized void completeDelayedConfiguration(OptimoveConfig config){
+        if (!config.usesDelayedOptimobileConfiguration()){
+            throw new IllegalStateException("Trying to complete optimobile init without using delayed configuration");
+        }
+        authHeader = buildBasicAuthHeader(config.getApiKey(), config.getSecretKey());
+
+        //TODO:
+        //1. sync in-apps
+        //2. flush events
+        //3. deep links
     }
 
     private static void maybeMigrateUserAssociation(Application application, @Nullable String customerId) {

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ In this guide we will discuss the steps necessary to implement the Optimove Andr
 4. [Deferred Deep Linking](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/deferred-deep-linking)
 5. [Testing](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/testing-troubleshooting)
 
+> **NOTE**:
+To unlock these capabilities, you will need to have added the relevant OptiMobile channels to your Optimove package. If you can’t see this feature in your Optimove instance, contact your CSM to find out more.
+
 ### Migrations
 
 1. [Migration from 6.x to 7.x](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Migration-guide-from-6.x-to-7.x)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ In this guide we will discuss the steps necessary to implement the Optimove Andr
 
 ### Advanced Setup
 
-6. [Tracking custom events](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Tracking-custom-events)
+1. [Tracking custom events](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Tracking-custom-events)
+2. [Location and Beacons](https://github.com/optimove-tech/Optimove-SDK-Android/wiki/Location-and-Beacons)
 
 ### Mobile Messaging
 


### PR DESCRIPTION
### Description of Changes

In this part 1 handle additions to the API. New constructor for config builder `Builder(region, featureSet)`. Feature set tells which bits of the sdk do we want to partially initialise (otherwise we could init one that never gets credentials resulting in caches endlessly growing).

1. credentials given immediately (old constructor). Trying to set credentials later results in an exception. Feature set depends on provided creds
2. new constructor.
- partial init for Optimobile means that events etc are cached. Caches are flushed when credentials given.
- partial init for Optimove means (currently) init when credentials are given. Only then optimove starts doing anything.
- not partially initing here means optimobile/optimove wont do anything, setting creds results in an exception

Additionally tweak test app to allow late setting of creds. Inputs appear only when delayed init is used.

<img src="https://github.com/optimove-tech/Optimove-SDK-Android/assets/102593050/02688a8e-de35-4af6-9684-5171c0a4beb3" width="300px"/>



TO COME:
1. flushing caches when credentials arrived
4. refactor early aborts if sdk is not fully initialised
5. cache optimove actions (?)
6. deep links

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [ ] CHANGELOG.md
- [ ] gradle.properties
- [ ] add links to newly created wiki pages to readme
- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
