### PR TITLE
201381 - setting credentials late [2/3]

### DIFF
--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/Optimove.java
@@ -177,7 +177,7 @@ final public class Optimove {
 
         currentConfig.setCredentials(optimoveCredentials, optimobileCredentials);
         if (optimobileCredentials != null && currentConfig.usesDelayedOptimobileConfiguration()){
-            Optimobile.completeDelayedConfiguration(currentConfig);
+            Optimobile.completeDelayedConfiguration(shared.getApplicationContext(), currentConfig);
         }
 
         if (optimoveCredentials != null && currentConfig.usesDelayedOptimoveConfiguration()){

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsContract.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsContract.java
@@ -115,11 +115,6 @@ final class AnalyticsContract {
                 return;
             }
 
-            //TODO: create wrapper http client and move this check there?
-            if (Optimobile.authHeader == null) {
-                return;
-            }
-
             if (immediateFlush) {
                 AnalyticsUploadHelper helper = new AnalyticsUploadHelper();
                 AnalyticsUploadHelper.Result result = helper.flushEvents(mContext);

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsUploadHelper.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/AnalyticsUploadHelper.java
@@ -28,6 +28,10 @@ class AnalyticsUploadHelper {
     };
 
     /** package */ Result flushEvents(Context context) {
+        if (!Optimobile.hasFinishedInitialisation()){
+            return Result.FAILED_RETRY_LATER;
+        }
+
         try (SQLiteOpenHelper dbHelper = new AnalyticsDbHelper(context)) {
             SQLiteDatabase db = dbHelper.getReadableDatabase();
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/DeferredDeepLinkHelper.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/DeferredDeepLinkHelper.java
@@ -252,7 +252,6 @@ public class DeferredDeepLinkHelper {
                 }
                 catch(Optimobile.PartialInitialisationException e){
                     //TODO: not supported. For ddl we could store url here and do request again when credentials given. This way we clipboard can be cleared as usual.
-                    throw e;
                 }
             }
         });
@@ -352,7 +351,6 @@ public class DeferredDeepLinkHelper {
         }
         catch(Optimobile.PartialInitialisationException e){
             //TODO: not supported.
-            throw e;
         };
     }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
@@ -25,7 +25,7 @@ class InAppRequestService {
 
     static List<InAppMessage> readInAppMessages(Context c, Date lastSyncTime) {
         //TODO: create wrapper http client and move this check there?
-        if (Optimobile.hasFinishedInitialisation()) {
+        if (Optimobile.hasFinishedHttpInitialisation()) {
             return null;
         }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
@@ -25,7 +25,7 @@ class InAppRequestService {
 
     static List<InAppMessage> readInAppMessages(Context c, Date lastSyncTime) {
         //TODO: create wrapper http client and move this check there?
-        if (Optimobile.authHeader == null) {
+        if (Optimobile.hasFinishedInitialisation()) {
             return null;
         }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppRequestService.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
 import okhttp3.Response;
 
 class InAppRequestService {
@@ -24,12 +22,7 @@ class InAppRequestService {
     private static final String TAG = InAppRequestService.class.getName();
 
     static List<InAppMessage> readInAppMessages(Context c, Date lastSyncTime) {
-        //TODO: create wrapper http client and move this check there?
-        if (Optimobile.hasFinishedHttpInitialisation()) {
-            return null;
-        }
-
-        OkHttpClient httpClient;
+        OptimobileHttpClient httpClient;
         String userIdentifier = Optimobile.getCurrentUserIdentifier(c);
 
         try {
@@ -40,39 +33,31 @@ class InAppRequestService {
         }
 
         String params = "";
-        if (lastSyncTime != null){
+        if (lastSyncTime != null) {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
             sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-            params= "?after="+ sdf.format(lastSyncTime);
+            params = "?after=" + sdf.format(lastSyncTime);
         }
         String encodedIdentifier = Uri.encode(userIdentifier);
-        String url = Optimobile.urlBuilder.urlForService(UrlBuilder.Service.PUSH, "/v1/users/"+encodedIdentifier+"/messages"+params);
-
-        final Request request = new Request.Builder()
-                .url(url)
-                .addHeader(Optimobile.KEY_AUTH_HEADER, Optimobile.authHeader)
-                .addHeader("Accept", "application/json")
-                .get()
-                .build();
+        String url = Optimobile.urlBuilder.urlForService(UrlBuilder.Service.PUSH, "/v1/users/" + encodedIdentifier + "/messages" + params);
 
         List<InAppMessage> messages = null;
-
-        try(Response response = httpClient.newCall(request).execute()) {
+        try (Response response = httpClient.getSync(url)) {
             if (!response.isSuccessful()) {
                 logFailedResponse(response);
-            }
-            else{
+            } else {
                 messages = getMessages(response);
             }
-        }
-        catch(IOException e){
+        } catch (IOException e) {
             e.printStackTrace();
+        } catch (Optimobile.PartialInitialisationException e) {
+            // noop
         }
 
         return messages;
     }
 
-    private static void logFailedResponse(Response response){
+    private static void logFailedResponse(Response response) {
         switch (response.code()) {
             case 404:
                 Optimobile.log(TAG, "User not found");
@@ -80,7 +65,7 @@ class InAppRequestService {
             case 422:
                 try {
                     Optimobile.log(TAG, response.body().string());
-                } catch (NullPointerException|IOException e) {
+                } catch (NullPointerException | IOException e) {
                     Optimobile.log(TAG, e.getMessage());
                 }
                 break;
@@ -90,7 +75,7 @@ class InAppRequestService {
         }
     }
 
-    private static List<InAppMessage> getMessages(Response response){
+    private static List<InAppMessage> getMessages(Response response) {
         try {
             JSONArray result = new JSONArray(response.body().string());
             List<InAppMessage> inAppMessages = new ArrayList<>();
@@ -102,8 +87,7 @@ class InAppRequestService {
             }
 
             return inAppMessages;
-        }
-        catch (NullPointerException| JSONException | ParseException | IOException e) {
+        } catch (NullPointerException | JSONException | ParseException | IOException e) {
             Optimobile.log(TAG, e.getMessage());
             return null;
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -76,6 +76,12 @@ public final class Optimobile {
         }
     }
 
+    static class PartialInitialisationException extends RuntimeException {
+        PartialInitialisationException() {
+            super("The Optimobile has not been fully initialised. Trying to make network requets without credntials");
+        }
+    }
+
 
     /**
      * Used to configure the Optimobile class. Only needs to be called once per process
@@ -143,7 +149,7 @@ public final class Optimobile {
         });
     }
 
-    static boolean hasFinishedInitialisation(){
+    static boolean hasFinishedHttpInitialisation(){
         return authHeader != null;
     }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -70,7 +70,7 @@ public final class Optimobile {
         }
     }
 
-    static class PartialInitialisationException extends RuntimeException {
+    static class PartialInitialisationException extends Exception {
         PartialInitialisationException() {
             super("The Optimobile has not been fully initialised. Trying to make network requets without credntials");
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimobileHttpClient.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimobileHttpClient.java
@@ -1,7 +1,12 @@
 package com.optimove.android.optimobile;
 
-import java.io.IOException;
+import android.os.Build;
 
+import java.io.IOException;
+import java.util.Collections;
+
+import okhttp3.Callback;
+import okhttp3.ConnectionSpec;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -11,34 +16,67 @@ import okhttp3.Response;
 class OptimobileHttpClient {
     private final OkHttpClient okHttpClient;
 
-    OptimobileHttpClient(){
-        okHttpClient = new OkHttpClient();
+    OptimobileHttpClient() {
+        okHttpClient = this.buildOkHttpClient();
+    }
+
+    private OkHttpClient buildOkHttpClient() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return new OkHttpClient();
+        }
+
+        //ciphers available on Android 4.4 have intersections with the approved ones in MODERN_TLS, but the intersections are on bad cipher list, so,
+        //perhaps not supported by CloudFlare. On older devices allow all ciphers
+        ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                .allEnabledCipherSuites()
+                .build();
+
+        return new OkHttpClient.Builder()
+                .connectionSpecs(Collections.singletonList(spec))
+                .build();
     }
 
     Response postSync(String url, String data) throws IOException, Optimobile.PartialInitialisationException {
         RequestBody body = RequestBody.create(data, MediaType.parse("application/json; charset=utf-8"));
 
         Request.Builder builder = new Request.Builder().post(body);
+        Request request = this.buildRequest(builder, url);
 
-        return this.doSyncRequest(builder, url);
+        return this.doSyncRequest(request);
     }
 
-    Response getSync(){
-        //TODO:
-        return null;
+    Response getSync(String url) throws IOException, Optimobile.PartialInitialisationException {
+        Request.Builder builder = new Request.Builder().get();
+
+        Request request = this.buildRequest(builder, url);
+
+        return this.doSyncRequest(request);
     }
 
-    private Response doSyncRequest(Request.Builder builder, String url) throws IOException, Optimobile.PartialInitialisationException{
-        if (!Optimobile.hasFinishedHttpInitialisation()){
+    void getAsync(String url, Callback callback) throws Optimobile.PartialInitialisationException {
+        Request.Builder builder = new Request.Builder().get();
+        Request request = this.buildRequest(builder, url);
+
+        this.doAsyncRequest(request, callback);
+    }
+
+    private Request buildRequest(Request.Builder builder, String url) {
+        if (!Optimobile.hasFinishedHttpInitialisation()) {
             throw new Optimobile.PartialInitialisationException();
         }
 
-        Request request = builder.url(url)
+        return builder.url(url)
                 .addHeader(Optimobile.KEY_AUTH_HEADER, Optimobile.authHeader)
                 .addHeader("Accept", "application/json")
                 .addHeader("Content-Type", "application/json")
                 .build();
+    }
 
+    private Response doSyncRequest(Request request) throws IOException {
         return this.okHttpClient.newCall(request).execute();
+    }
+
+    private void doAsyncRequest(Request request, Callback callback) {
+        this.okHttpClient.newCall(request).enqueue(callback);
     }
 }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimobileHttpClient.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimobileHttpClient.java
@@ -60,7 +60,7 @@ class OptimobileHttpClient {
         this.doAsyncRequest(request, callback);
     }
 
-    private Request buildRequest(Request.Builder builder, String url) {
+    private Request buildRequest(Request.Builder builder, String url) throws Optimobile.PartialInitialisationException {
         if (!Optimobile.hasFinishedHttpInitialisation()) {
             throw new Optimobile.PartialInitialisationException();
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimobileHttpClient.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimobileHttpClient.java
@@ -1,0 +1,44 @@
+package com.optimove.android.optimobile;
+
+import java.io.IOException;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+class OptimobileHttpClient {
+    private final OkHttpClient okHttpClient;
+
+    OptimobileHttpClient(){
+        okHttpClient = new OkHttpClient();
+    }
+
+    Response postSync(String url, String data) throws IOException, Optimobile.PartialInitialisationException {
+        RequestBody body = RequestBody.create(data, MediaType.parse("application/json; charset=utf-8"));
+
+        Request.Builder builder = new Request.Builder().post(body);
+
+        return this.doSyncRequest(builder, url);
+    }
+
+    Response getSync(){
+        //TODO:
+        return null;
+    }
+
+    private Response doSyncRequest(Request.Builder builder, String url) throws IOException, Optimobile.PartialInitialisationException{
+        if (!Optimobile.hasFinishedHttpInitialisation()){
+            throw new Optimobile.PartialInitialisationException();
+        }
+
+        Request request = builder.url(url)
+                .addHeader(Optimobile.KEY_AUTH_HEADER, Optimobile.authHeader)
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .build();
+
+        return this.okHttpClient.newCall(request).execute();
+    }
+}


### PR DESCRIPTION
### Description of Changes

- Refactor early aborts if sdk is not fully initialised. Create OptimobileHttpClient wrapping OkHttp. The client checks authHeader is present, if not throws checked PartialInitialisationException. Up to consumer what to do with it.

TO COME:

1. flushing caches when credentials arrived
2. deep links
3. cache optimove actions (?)



### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [ ] CHANGELOG.md
- [ ] gradle.properties
- [ ] add links to newly created wiki pages to readme
- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
