### PR TITLE
Fix: unexpected sound playing if provided sound does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.3.1
+
+- Fix: don't set custom sound if provided resource doesn't exist
+
 ## 7.3.0
 
 - Support late setting of credentials with partial initialisation

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,7 +8,7 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.3.0
+sdk_version=7.3.1
 sdk_version_code=70300
 sdk_platform=Android
 android.useAndroidX=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
@@ -383,7 +383,10 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
         Uri ringtoneSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         if (soundFileName != null) {
-            ringtoneSound = Uri.parse("android.resource://" + context.getPackageName() + "/raw/" + soundFileName);
+            int resourceId = context.getResources().getIdentifier(soundFileName, "raw", context.getPackageName());
+            if (resourceId != 0) {
+                ringtoneSound = Uri.parse("android.resource://" + context.getPackageName() + "/raw/" + soundFileName);
+            }
         }
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {


### PR DESCRIPTION
### Description of Changes

When RingtoneManager is provided a resource that does not exist, it plays "another sound".

https://developer.android.com/reference/kotlin/android/media/RingtoneManager#getringtone_1

Check existence of a resource before setting it.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [x] CHANGELOG.md
- [x] gradle.properties
- [x] add links to newly created wiki pages to readme
- [x] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
