### PR TITLE
updated sdk to avoid menmory leack caused by InAppDeeplink handler

### DIFF
--- a/OptimoveSDK/app/build.gradle
+++ b/OptimoveSDK/app/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     testImplementation 'junit:junit:4.12'
 
+    // LeakCanary for debug builds only
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
+
     // implementation platform('com.google.firebase:firebase-bom:28.2.0')
     // implementation 'com.google.firebase:firebase-messaging'
 }

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.java
@@ -17,6 +17,7 @@ import androidx.core.content.ContextCompat;
 
 import com.optimove.android.Optimove;
 import com.optimove.android.main.events.OptimoveEvent;
+import com.optimove.android.optimobile.InAppDeepLinkHandlerInterface;
 import com.optimove.android.optimobile.InAppInboxItem;
 import com.optimove.android.optimobile.OptimoveInApp;
 import com.optimove.android.preferencecenter.Channel;
@@ -46,6 +47,15 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         outputTv = findViewById(R.id.userIdTextView);
 
+
+        OptimoveInApp.getInstance().setDeepLinkHandler(new InAppDeepLinkHandlerInterface() {
+            @Override
+            public void handle(android.content.Context context, InAppButtonPress buttonPress) {
+                Log.d(TAG, "DeepLink handler invoked");
+                startActivity(new Intent(MainActivity.this, MainActivity.class)); // or any Activity you have
+            }
+        });
+
         this.hideIrrelevantInputs();
 
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
@@ -54,6 +64,12 @@ public class MainActivity extends AppCompatActivity {
 
         //deferred deep links
         Optimove.getInstance().seeIntent(getIntent(), savedInstanceState);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        Log.d(TAG, "MainActivity.onDestroy called");
     }
 
     @Override
@@ -90,6 +106,13 @@ public class MainActivity extends AppCompatActivity {
         outputTv.setText("Reporting Custom Event for Visitor without optional value");
         runFromWorker(() -> Optimove.getInstance().reportEvent(new SimpleCustomEvent()));
         runFromWorker(() -> Optimove.getInstance().reportEvent("Event_No ParaMs     "));
+    }
+
+    public void killActivity(View view) {
+        if (view == null)
+            return;
+        Log.d("TAG", "killActivity called");
+        finish(); // forces MainActivity.onDestroy() right now
     }
 
     public void updateUserId(View view) {

--- a/OptimoveSDK/app/src/main/res/layout/activity_main.xml
+++ b/OptimoveSDK/app/src/main/res/layout/activity_main.xml
@@ -231,12 +231,20 @@
                 android:ems="10"
                 android:hint="Preference center credentials (optional)"
                 android:inputType="textPersonName" />
+
             <Button
                 android:id="@+id/submitCredentialsBtn"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:onClick="setCredentials"
                 android:text="Submit credentials" />
+
+            <Button
+                android:id="@+id/KillActivity"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:onClick="killActivity"
+                android:text="Kill Activity" />
 
         </LinearLayout>
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveInApp.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveInApp.java
@@ -157,8 +157,13 @@ public class OptimoveInApp {
      *
      * @param handler
      */
-    public void setDeepLinkHandler(InAppDeepLinkHandlerInterface handler) {
-        this.inAppDeepLinkHandler = handler;
+    public void setDeepLinkHandler(@Nullable InAppDeepLinkHandlerInterface handler) {
+        if (handler == null) {
+            this.inAppDeepLinkHandler = null;
+        } else {
+            // Store a strong ref to a wrapper that only weakly references the app's handler
+            this.inAppDeepLinkHandler = new WeakDeepLinkHandler(application, handler);
+        }
     }
 
     public void setDisplayMode(OptimoveConfig.InAppDisplayMode mode) {
@@ -264,5 +269,49 @@ public class OptimoveInApp {
         }
 
         Optimobile.handler.post(inboxUpdatedHandler);
+    }
+
+    private static final class WeakDeepLinkHandler implements InAppDeepLinkHandlerInterface {
+        private static final String TAG = "OptimoveInApp";
+        private final java.lang.ref.WeakReference<InAppDeepLinkHandlerInterface> delegateRef;
+        private final android.content.Context appContext;
+        // Optional strict flag (wire this from your config if you like)
+        private final boolean strictMode;
+
+        WeakDeepLinkHandler(@NonNull android.content.Context context,
+                            @NonNull InAppDeepLinkHandlerInterface delegate) {
+            this(context, delegate, /*strictMode=*/false);
+        }
+
+        WeakDeepLinkHandler(@NonNull android.content.Context context,
+                            @NonNull InAppDeepLinkHandlerInterface delegate,
+                            boolean strictMode) {
+            this.appContext = context.getApplicationContext();
+            this.delegateRef = new java.lang.ref.WeakReference<>(delegate);
+            this.strictMode = strictMode;
+        }
+
+        @Override
+        public void handle(android.content.Context context,
+                           InAppButtonPress buttonPress) {
+            InAppDeepLinkHandlerInterface delegate = delegateRef.get();
+            if (delegate == null) return;
+
+            try {
+                // Use app context to avoid propagating an Activity reference
+                delegate.handle(appContext, buttonPress);
+            } catch (RuntimeException e) {
+                // Log with full stacktrace so integrators see the failure in Logcat
+                android.util.Log.e(TAG, "DeepLinkHandler threw a RuntimeException", e);
+                if (strictMode) throw e; // crash in strict/debug builds if desired
+            } catch (Throwable t) {
+                // Catch-all to prevent app crash, but still surface it
+                android.util.Log.e(TAG, "DeepLinkHandler threw a non-fatal Throwable", t);
+                if (strictMode) {
+                    // Wrapping in RuntimeException so you can opt-in to fail fast
+                    throw new RuntimeException("DeepLinkHandler non-fatal error", t);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description of Changes

This update fixes a memory leak in `OptimoveInApp.setDeepLinkHandler`.  
Previously the SDK held a strong reference to the app’s handler, which could capture an `Activity` and keep it alive after `onDestroy()`.  

The fix introduces a `WeakDeepLinkHandler` wrapper that stores the handler via `WeakReference` and delegates calls using the `applicationContext`.  
This prevents Activities from leaking while keeping the API unchanged and backward compatible.  

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [ ] CHANGELOG.md
- [ ] gradle.properties
- [ ] add links to newly created wiki pages to readme
- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
