### PR TITLE
AB#279398 Add Interceptor Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 7.12.2
+
+-  Introduces a lastShownByInterceptorId field that tracks which message was last shown through the interceptor, preventing duplicate interception of the same head message.
+
 ## 7.12.1
 
 - Fixed bug where postponed in-app message queue survived username and consent changes. In-app presentation queue now clears on identity or in-app consent changes.

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -7,8 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-sdk_version=7.12.1
-sdk_version_code=71201
+sdk_version=7.12.2
+sdk_version_code=71202
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
@@ -40,6 +40,7 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
     private InAppMessageView view;
 
     private boolean interceptionInProgress = false;
+    private int lastShownByInterceptorId = -1;
 
     InAppMessagePresenter(Context context, @NonNull OptimoveConfig.InAppDisplayMode defaultDisplayMode) {
         this.context = context.getApplicationContext();
@@ -127,6 +128,7 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
     void cancelCurrentPresentationQueue() {
         messageQueue.clear();
         interceptionInProgress = false;
+        lastShownByInterceptorId = -1;
         disposeView();
     }
 
@@ -167,7 +169,7 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
                 return;
             }
 
-            if (messageInterceptor != null) {
+            if (messageInterceptor != null && currentMessage.getInAppId() != lastShownByInterceptorId) {
                 interceptionInProgress = true;
                 applyMessageInterception(currentMessage);
                 return;
@@ -185,9 +187,11 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
             if (interceptionInProgress) {
                 return;
             }
-            interceptionInProgress = true;
-            applyMessageInterception(currentMessage);
-            return;
+            if (currentMessage.getInAppId() != lastShownByInterceptorId) {
+                interceptionInProgress = true;
+                applyMessageInterception(currentMessage);
+                return;
+            }
         }
 
         showMessageDirectly(currentMessage);
@@ -278,6 +282,7 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
                 }
                 Optimobile.handler.post(() -> {
                     interceptionInProgress = false;
+                    lastShownByInterceptorId = message.getInAppId();
                     if (view != null) {
                         view.showMessage(message);
                     } else {

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessagePresenter.java
@@ -140,6 +140,7 @@ class InAppMessagePresenter implements AppStateWatcher.AppStateChangedListener {
         }
 
         messageQueue.remove(0);
+        lastShownByInterceptorId = -1;
 
         presentMessageToClient();
     }


### PR DESCRIPTION
### Description of Changes

On Android, the in-app message interceptor can be re-triggered for the same head message when `presentMessageToClient()` is re-entered (e.g. via activity lifecycle transitions). This change introduces a `lastShownByInterceptorId` field that tracks which message was last shown through the interceptor, preventing duplicate interception of the same head message whilst still allowing the interceptor to fire normally for subsequent messages in the queue.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [x] CHANGELOG.md
- [x] gradle.properties
- [ ] add links to newly created wiki pages to readme
- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
