### PR TITLE
AB#280444 - Add Gamify Widget SDK module and QA app integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 7.13.0
+
+- Added Gamify Widget SDK module: a WebView-based bottom sheet that loads Optimove widget URLs and communicates with the widget via a JavaScript bridge
+
 ## 7.12.2
 
 -  Introduces a lastShownByInterceptorId field that tracks which message was last shown through the interceptor, preventing duplicate interception of the same head message.

--- a/OptimoveSDK/app/build.gradle
+++ b/OptimoveSDK/app/build.gradle
@@ -5,6 +5,7 @@ android {
     compileSdk 34
     defaultConfig {
         applicationId "com.optimove.android.optimovemobilesdk"
+        multiDexEnabled true
         minSdk 21
         targetSdk 34
         versionCode Integer.parseInt("$sdk_version_code")
@@ -40,6 +41,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':optimove-sdk')
+    implementation project(':gamify-widget-sdk')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'

--- a/OptimoveSDK/app/src/main/AndroidManifest.xml
+++ b/OptimoveSDK/app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
             android:name="com.optimove.android.optimovemobilesdk.EmbeddedMessagingActivity"
             android:parentActivityName=".MainActivity"/>
         <activity
+            android:name="com.optimove.android.optimovemobilesdk.GamifyWidgetActivity"
+            android:exported="false"
+            android:parentActivityName=".MainActivity"/>
+        <activity
             android:name="com.optimove.android.optimovemobilesdk.DeeplinkTargetActivity"
             android:parentActivityName=".MainActivity"
             android:exported="true">

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/GamifyWidgetActivity.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/GamifyWidgetActivity.kt
@@ -1,0 +1,72 @@
+package com.optimove.android.optimovemobilesdk
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.optimove.android.gamifywidgetsdk.GamifyWidgetSDK
+import com.optimove.android.optimovemobilesdk.ui.GamifyWidgetScreen
+import com.optimove.android.optimovemobilesdk.ui.theme.AppTheme
+
+enum class GamifyEnv(val label: String, val baseUrl: String) {
+    DEV("Dev", "https://opti-ls-widget-dev.optimove.net"),
+    PROD_US("Prod US", "https://opti-ls-widget-us.optimove.net"),
+    PROD_EU("Prod EU", "https://opti-ls-widget-eu.optimove.net")
+}
+
+class GamifyWidgetActivity : AppCompatActivity() {
+
+    private lateinit var prefs: SharedPreferences
+
+    private var tenant by mutableStateOf("")
+    private var userId by mutableStateOf("")
+    private var env by mutableStateOf(GamifyEnv.DEV)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        tenant = prefs.getString(KEY_TENANT, "") ?: ""
+        userId = prefs.getString(KEY_USER_ID, "") ?: ""
+        env = enumValues<GamifyEnv>().find { it.name == prefs.getString(KEY_ENV, null) } ?: GamifyEnv.DEV
+
+        setContent {
+            AppTheme {
+                GamifyWidgetScreen(
+                    tenant = tenant,
+                    userId = userId,
+                    env = env,
+                    onTenantChange = { tenant = it; save() },
+                    onWidgetIdChange = { userId = it; save() },
+                    onEnvChange = { env = it; save() },
+                    onOpenWidget = ::openWidget
+                )
+            }
+        }
+    }
+
+    private fun save() {
+        prefs.edit()
+            .putString(KEY_TENANT, tenant)
+            .putString(KEY_USER_ID, userId)
+            .putString(KEY_ENV, env.name)
+            .apply()
+    }
+
+    private fun openWidget() {
+        val widgetUrl = "${env.baseUrl}/$tenant/$userId"
+        GamifyWidgetSDK.init(widgetUrl = widgetUrl)
+        GamifyWidgetSDK.open(supportFragmentManager)
+    }
+
+    companion object {
+        private const val PREFS_NAME = "gamify_widget_config"
+        private const val KEY_TENANT = "tenant"
+        private const val KEY_USER_ID = "user_id"
+        private const val KEY_ENV = "env"
+    }
+}

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MainActivity.kt
@@ -35,6 +35,7 @@ import com.optimove.android.preferencecenter.OptimovePreferenceCenter
 import com.optimove.android.preferencecenter.PreferenceUpdate
 import com.optimove.android.preferencecenter.Topic
 import com.optimove.android.optimovemobilesdk.ui.MainScreen
+
 import com.optimove.android.optimovemobilesdk.ui.theme.AppTheme
 import org.json.JSONObject
 
@@ -146,7 +147,8 @@ class MainActivity : AppCompatActivity() {
                             "Delayed init enabled — restart app to apply"
                         else
                             "Immediate init enabled — restart app to apply"
-                    }
+                    },
+                    onOpenGamifyWidget = ::openGamifyWidget
                 )
             }
         }
@@ -314,6 +316,10 @@ class MainActivity : AppCompatActivity() {
 
     private fun viewEmbeddedMessaging() {
         startActivity(Intent(this, EmbeddedMessagingActivity::class.java))
+    }
+
+    private fun openGamifyWidget() {
+        startActivity(Intent(this, GamifyWidgetActivity::class.java))
     }
 
     private fun openDeeplinkTest() {

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/ui/GamifyWidgetScreen.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/ui/GamifyWidgetScreen.kt
@@ -1,0 +1,125 @@
+package com.optimove.android.optimovemobilesdk.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.optimove.android.optimovemobilesdk.GamifyEnv
+import androidx.compose.foundation.layout.Row
+
+private val CardShape = RoundedCornerShape(12.dp)
+private val SectionPadding = 16.dp
+
+@Composable
+fun GamifyWidgetScreen(
+    tenant: String,
+    userId: String,
+    env: GamifyEnv,
+    onTenantChange: (String) -> Unit,
+    onWidgetIdChange: (String) -> Unit,
+    onEnvChange: (GamifyEnv) -> Unit,
+    onOpenWidget: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(SectionPadding)
+    ) {
+        Text(
+            "Gamify Widget",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = CardShape,
+            color = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Column(
+                modifier = Modifier.padding(SectionPadding),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedTextField(
+                    value = tenant,
+                    onValueChange = onTenantChange,
+                    label = { Text("Tenant") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        focusedLabelColor = MaterialTheme.colorScheme.primary,
+                        cursorColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+                OutlinedTextField(
+                    value = userId,
+                    onValueChange = onWidgetIdChange,
+                    label = { Text("User ID") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        focusedLabelColor = MaterialTheme.colorScheme.primary,
+                        cursorColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+                Text(
+                    "Environment",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    enumValues<GamifyEnv>().forEach { option ->
+                        if (env == option) {
+                            Button(
+                                onClick = { onEnvChange(option) },
+                                shape = RoundedCornerShape(10.dp)
+                            ) {
+                                Text(option.label)
+                            }
+                        } else {
+                            OutlinedButton(
+                                onClick = { onEnvChange(option) },
+                                shape = RoundedCornerShape(10.dp),
+                                colors = ButtonDefaults.outlinedButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            ) {
+                                Text(option.label)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onOpenWidget,
+            enabled = tenant.isNotBlank() && userId.isNotBlank(),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(10.dp)
+        ) {
+            Text("Open Widget")
+        }
+    }
+}

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/ui/MainScreen.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/ui/MainScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -70,7 +69,8 @@ fun MainScreen(
     onRegisterPush: () -> Unit,
     onUnregisterPush: () -> Unit,
     isDelayedInit: Boolean,
-    onDelayedInitToggle: (Boolean) -> Unit
+    onDelayedInitToggle: (Boolean) -> Unit,
+    onOpenGamifyWidget: () -> Unit
 ) {
     var optimoveCred by remember {
         mutableStateOf(if (showDelayedConfig) MyApplication.DEFAULT_OPTIMOVE_CRED else "")
@@ -330,6 +330,14 @@ fun MainScreen(
                     }
                 }
             }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Button(
+            onClick = onOpenGamifyWidget,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(10.dp)
+        ) {
+            Text("Open Gamify Widget")
         }
         Spacer(modifier = Modifier.height(12.dp))
         Button(

--- a/OptimoveSDK/gamify-widget-sdk/build.gradle
+++ b/OptimoveSDK/gamify-widget-sdk/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.6.2'
     implementation 'com.google.android.material:material:1.9.0'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.json:json:20230227'
     testImplementation 'org.mockito:mockito-core:5.11.0'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.3.1'
 }

--- a/OptimoveSDK/gamify-widget-sdk/build.gradle
+++ b/OptimoveSDK/gamify-widget-sdk/build.gradle
@@ -19,6 +19,7 @@ android {
         }
     }
 
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/OptimoveSDK/gamify-widget-sdk/build.gradle
+++ b/OptimoveSDK/gamify-widget-sdk/build.gradle
@@ -1,0 +1,39 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace 'com.optimove.android.gamifywidgetsdk'
+    compileSdk 34
+
+    defaultConfig {
+        minSdk 21
+        targetSdk 34
+        consumerProguardFiles 'proguard-rules.pro'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.fragment:fragment-ktx:1.6.2'
+    implementation 'com.google.android.material:material:1.9.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.3.1'
+}

--- a/OptimoveSDK/gamify-widget-sdk/proguard-rules.pro
+++ b/OptimoveSDK/gamify-widget-sdk/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.optimove.android.gamifywidgetsdk.** { *; }

--- a/OptimoveSDK/gamify-widget-sdk/src/main/AndroidManifest.xml
+++ b/OptimoveSDK/gamify-widget-sdk/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.kt
@@ -1,6 +1,5 @@
 package com.optimove.android.gamifywidgetsdk
 
-import android.util.Log
 import android.webkit.JavascriptInterface
 
 /**
@@ -18,20 +17,13 @@ internal class AndroidBridge(
 
     @JavascriptInterface
     fun closeWidget() {
-        Log.d(TAG, "closeWidget called")
         onClose()
     }
 
     @JavascriptInterface
     fun receiveMessage(json: String) {
-        Log.d(TAG, "receiveMessage: $json")
         if (json.contains("\"type\":\"READY\"")) {
-            Log.d(TAG, "READY received — sending INIT")
             onReady()
         }
-    }
-
-    companion object {
-        private const val TAG = "GamifyBridge"
     }
 }

--- a/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.kt
@@ -1,0 +1,37 @@
+package com.optimove.android.gamifywidgetsdk
+
+import android.util.Log
+import android.webkit.JavascriptInterface
+
+/**
+ * Native bridge exposed to the widget's JavaScript as `window.AndroidBridge`.
+ *
+ * The widget calls:
+ *   window.AndroidBridge.closeWidget()        — to dismiss the bottom sheet
+ *   window.AndroidBridge.receiveMessage(json) — generic widget → SDK messages,
+ *       including the READY handshake (type = "READY")
+ */
+internal class AndroidBridge(
+    private val onClose: () -> Unit,
+    private val onReady: () -> Unit
+) {
+
+    @JavascriptInterface
+    fun closeWidget() {
+        Log.d(TAG, "closeWidget called")
+        onClose()
+    }
+
+    @JavascriptInterface
+    fun receiveMessage(json: String) {
+        Log.d(TAG, "receiveMessage: $json")
+        if (json.contains("\"type\":\"READY\"")) {
+            Log.d(TAG, "READY received — sending INIT")
+            onReady()
+        }
+    }
+
+    companion object {
+        private const val TAG = "GamifyBridge"
+    }
+}

--- a/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.kt
@@ -1,6 +1,9 @@
 package com.optimove.android.gamifywidgetsdk
 
+import android.util.Log
 import android.webkit.JavascriptInterface
+import org.json.JSONException
+import org.json.JSONObject
 
 /**
  * Native bridge exposed to the widget's JavaScript as `window.AndroidBridge`.
@@ -22,8 +25,16 @@ internal class AndroidBridge(
 
     @JavascriptInterface
     fun receiveMessage(json: String) {
-        if (json.contains("\"type\":\"READY\"")) {
-            onReady()
+        try {
+            if (JSONObject(json).getString("type") == "READY") {
+                onReady()
+            }
+        } catch (e: JSONException) {
+            Log.d(TAG, "Incorrect message format: $json")
         }
+    }
+
+    companion object {
+        private const val TAG = "GamifyWidget"
     }
 }

--- a/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDK.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDK.kt
@@ -1,0 +1,40 @@
+package com.optimove.android.gamifywidgetsdk
+
+import androidx.fragment.app.FragmentManager
+
+/**
+ * Entry point for the Gamify Widget SDK.
+ *
+ * Usage:
+ *   GamifyWidgetSDK.init(widgetUrl = "https://your-widget.vercel.app")
+ *   GamifyWidgetSDK.open(supportFragmentManager, userId = "u123")
+ */
+object GamifyWidgetSDK {
+
+    internal var widgetUrl: String = ""
+        private set
+
+    fun init(widgetUrl: String) {
+        this.widgetUrl = widgetUrl
+    }
+
+    /**
+     * Opens the widget in a BottomSheet.
+     *
+     * @param fragmentManager  Activity's supportFragmentManager
+     * @param userId           Optional user ID injected into the widget via INIT
+     * @param token            Optional auth token injected into the widget via INIT
+     */
+    fun open(
+        fragmentManager: FragmentManager,
+        userId: String? = null,
+        token: String? = null
+    ) {
+        val sheet = WidgetBottomSheet.newInstance(
+            widgetUrl = widgetUrl,
+            userId = userId,
+            token = token
+        )
+        sheet.show(fragmentManager, WidgetBottomSheet.FRAGMENT_TAG)
+    }
+}

--- a/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/WidgetBottomSheet.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/WidgetBottomSheet.kt
@@ -1,0 +1,159 @@
+package com.optimove.android.gamifywidgetsdk
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.util.Log
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.json.JSONObject
+
+internal class WidgetBottomSheet : BottomSheetDialogFragment() {
+
+    private lateinit var webView: WebView
+    private lateinit var progressBar: ProgressBar
+    private lateinit var errorView: TextView
+
+    private val widgetUrl: String get() = arguments?.getString(ARG_WIDGET_URL) ?: ""
+    private val userId: String? get() = arguments?.getString(ARG_USER_ID)
+    private val token: String? get() = arguments?.getString(ARG_TOKEN)
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val root = FrameLayout(requireContext())
+
+        // WebView
+        webView = WebView(requireContext()).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
+            settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                loadWithOverviewMode = true
+                useWideViewPort = true
+            }
+            addJavascriptInterface(
+                AndroidBridge(
+                    onClose = { activity?.runOnUiThread { dismiss() } },
+                    onReady = { activity?.runOnUiThread { sendInit() } }
+                ),
+                "AndroidBridge"
+            )
+            webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView, url: String) {
+                    activity?.runOnUiThread { progressBar.visibility = View.GONE }
+                }
+
+                override fun onReceivedError(
+                    view: WebView,
+                    request: WebResourceRequest,
+                    error: WebResourceError
+                ) {
+                    if (request.isForMainFrame) {
+                        activity?.runOnUiThread { showError() }
+                    }
+                }
+            }
+        }
+
+        // Loading spinner
+        progressBar = ProgressBar(requireContext()).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                android.view.Gravity.CENTER
+            )
+        }
+
+        // Error state
+        errorView = TextView(requireContext()).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                android.view.Gravity.CENTER
+            )
+            text = "Unable to load widget.\nCheck your connection and try again."
+            textAlignment = View.TEXT_ALIGNMENT_CENTER
+            visibility = View.GONE
+        }
+
+        root.addView(webView)
+        root.addView(progressBar)
+        root.addView(errorView)
+
+        webView.loadUrl(widgetUrl)
+        return root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // Expand the bottom sheet fully on open
+        val bottomSheet = (dialog as? BottomSheetDialog)
+            ?.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+        bottomSheet?.let {
+            BottomSheetBehavior.from(it).apply {
+                state = BottomSheetBehavior.STATE_EXPANDED
+                skipCollapsed = true
+            }
+        }
+    }
+
+    /**
+     * Called by AndroidBridge.onReady() when the widget fires its READY signal.
+     * Posts the INIT payload back via window.postMessage so useBridge picks it up.
+     */
+    private fun sendInit() {
+        val initJson = buildInitJson()
+        Log.d(TAG, "sending INIT: $initJson")
+        webView.evaluateJavascript("window.postMessage($initJson, '*');", null)
+    }
+
+    private fun buildInitJson(): String {
+        val obj = JSONObject().apply {
+            put("type", "INIT")
+            userId?.let { put("userId", it) }
+            token?.let { put("token", it) }
+        }
+        return obj.toString()
+    }
+
+    private fun showError() {
+        progressBar.visibility = View.GONE
+        webView.visibility = View.GONE
+        errorView.visibility = View.VISIBLE
+    }
+
+    companion object {
+        private const val TAG = "GamifyWidget"
+        const val FRAGMENT_TAG = "WidgetBottomSheet"
+        private const val ARG_WIDGET_URL = "widget_url"
+        private const val ARG_USER_ID = "user_id"
+        private const val ARG_TOKEN = "token"
+
+        fun newInstance(widgetUrl: String, userId: String?, token: String?): WidgetBottomSheet {
+            return WidgetBottomSheet().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_WIDGET_URL, widgetUrl)
+                    userId?.let { putString(ARG_USER_ID, it) }
+                    token?.let { putString(ARG_TOKEN, it) }
+                }
+            }
+        }
+    }
+}

--- a/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/WidgetBottomSheet.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/WidgetBottomSheet.kt
@@ -16,6 +16,7 @@ import android.util.Log
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.json.JSONException
 import org.json.JSONObject
 
 internal class WidgetBottomSheet : BottomSheetDialogFragment() {
@@ -120,8 +121,18 @@ internal class WidgetBottomSheet : BottomSheetDialogFragment() {
      */
     private fun sendInit() {
         val initJson = buildInitJson()
-        Log.d(TAG, "sending INIT: $initJson")
+        Log.d(TAG, "sending INIT: ${redactedLog(initJson)}")
         webView.evaluateJavascript("window.postMessage($initJson, '*');", null)
+    }
+
+    private fun redactedLog(json: String): String {
+        return try {
+            val obj = JSONObject(json)
+            if (obj.has("token")) obj.put("token", "[REDACTED]")
+            obj.toString()
+        } catch (_: JSONException) {
+            "[unparseable]"
+        }
     }
 
     private fun buildInitJson(): String {

--- a/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.kt
@@ -9,14 +9,14 @@ class AndroidBridgeTest {
     @Test
     fun `closeWidget invokes onClose callback`() {
         val onClose = mock<() -> Unit>()
-        val bridge = AndroidBridge(onClose)
+        val bridge = AndroidBridge(onClose = onClose, onReady = {})
         bridge.closeWidget()
         verify(onClose).invoke()
     }
 
     @Test
     fun `receiveMessage does not throw`() {
-        val bridge = AndroidBridge(onClose = {})
+        val bridge = AndroidBridge(onClose = {}, onReady = {})
         bridge.receiveMessage("""{"type":"TEST"}""")
     }
 }

--- a/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.kt
@@ -2,6 +2,7 @@ package com.optimove.android.gamifywidgetsdk
 
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class AndroidBridgeTest {
@@ -15,8 +16,19 @@ class AndroidBridgeTest {
     }
 
     @Test
-    fun `receiveMessage does not throw`() {
-        val bridge = AndroidBridge(onClose = {}, onReady = {})
-        bridge.receiveMessage("""{"type":"TEST"}""")
+    fun `receiveMessage invokes onReady for READY type`() {
+        val onReady = mock<() -> Unit>()
+        val bridge = AndroidBridge(onClose = {}, onReady = onReady)
+        bridge.receiveMessage("""{"type":"READY"}""")
+        verify(onReady).invoke()
     }
+
+    @Test
+    fun `receiveMessage does not invoke onReady for other types`() {
+        val onReady = mock<() -> Unit>()
+        val bridge = AndroidBridge(onClose = {}, onReady = onReady)
+        bridge.receiveMessage("""{"type":"TEST"}""")
+        verify(onReady, never()).invoke()
+    }
+
 }

--- a/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.kt
@@ -1,0 +1,22 @@
+package com.optimove.android.gamifywidgetsdk
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class AndroidBridgeTest {
+
+    @Test
+    fun `closeWidget invokes onClose callback`() {
+        val onClose = mock<() -> Unit>()
+        val bridge = AndroidBridge(onClose)
+        bridge.closeWidget()
+        verify(onClose).invoke()
+    }
+
+    @Test
+    fun `receiveMessage does not throw`() {
+        val bridge = AndroidBridge(onClose = {})
+        bridge.receiveMessage("""{"type":"TEST"}""")
+    }
+}

--- a/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDKTest.kt
+++ b/OptimoveSDK/gamify-widget-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDKTest.kt
@@ -1,0 +1,28 @@
+package com.optimove.android.gamifywidgetsdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GamifyWidgetSDKTest {
+
+    @Before
+    fun setUp() {
+        // Reset state between tests via init
+        GamifyWidgetSDK.init(widgetUrl = "")
+    }
+
+    @Test
+    fun `init stores widgetUrl correctly`() {
+        val url = "https://gamify-widget.vercel.app"
+        GamifyWidgetSDK.init(widgetUrl = url)
+        assertEquals(url, GamifyWidgetSDK.widgetUrl)
+    }
+
+    @Test
+    fun `init overwrites previous url`() {
+        GamifyWidgetSDK.init(widgetUrl = "https://first.example.com")
+        GamifyWidgetSDK.init(widgetUrl = "https://second.example.com")
+        assertEquals("https://second.example.com", GamifyWidgetSDK.widgetUrl)
+    }
+}

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -7,8 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-sdk_version=7.12.2
-sdk_version_code=71202
+sdk_version=7.13.0
+sdk_version_code=71300
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/settings.gradle
+++ b/OptimoveSDK/settings.gradle
@@ -1,2 +1,1 @@
-include ':optimove-sdk'
-include ':app'
+include ':optimove-sdk', ':gamify-widget-sdk', ':app'


### PR DESCRIPTION
<img width="364" height="759" alt="image" src="https://github.com/user-attachments/assets/0d6d6f8a-5561-4239-95bf-2c1e54285819" />
<img width="369" height="762" alt="image" src="https://github.com/user-attachments/assets/22449ca0-8fd3-483c-a37e-e01d7203a3ec" />
<img width="367" height="763" alt="image" src="https://github.com/user-attachments/assets/63227417-ca3a-43aa-a1c0-445e9d88ad89" />



## Summary

- Introduces `gamify-widget-sdk` as a new standalone Android library module (mirrors `optimove-sdk` structure for future Maven publishing)
- Adds `GamifyWidgetSDK` entry point with `init(widgetUrl)` and `open(fragmentManager)` API
- Renders the widget in a `BottomSheetDialogFragment` via `WebView` with a JavaScript bridge (`AndroidBridge`) for widget-to-native communication
- Adds `GamifyWidgetActivity` + `GamifyWidgetScreen` to the QA app: Tenant, User ID, and environment (Dev / Prod US / Prod EU) inputs persisted in `SharedPreferences`
- Widget URL constructed as `{baseUrl}/{tenant}/{userId}` with three real environment base URLs

## Test plan

- [ ] Open QA app → tap "Open Gamify Widget"
- [ ] Verify `GamifyWidgetActivity` opens with Tenant, User ID, and env selector fields
- [ ] Enter tenant `60033`, user ID `e7776ce5-a430-4408-8bf4-050b377ec2aa`, select Dev
- [ ] Tap "Open Widget" — verify `https://opti-ls-widget-dev.optimove.net/60033/e7776ce5-a430-4408-8bf4-050b377ec2aa` loads in the bottom sheet
- [ ] Close the bottom sheet, reopen `GamifyWidgetActivity` — verify values are still populated
- [ ] Verify Prod US and Prod EU env selections produce correct base URLs
- [ ] Run unit tests: `./gradlew :gamify-widget-sdk:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)