### PR TITLE
AB#282352 bugfix: handle low-probability exception of Pendingresult.finish in PushBroadcastReceiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.12.5
+
+- Wrap pendingResult.finish() in PushBroadcastReceiver with try-cache
+
 ## 7.12.4
 
 - Replaces `WeakDeepLinkHandler` with `LifecycleBoundDeepLinkHandler`, which holds a strong reference to the delegate but binds to the Activity that was current when setDeepLinkHandler was called. When that Activity is destroyed, the handler and lifecycle callback are automatically cleaned up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.12.5
 
-- Wrap pendingResult.finish() in PushBroadcastReceiver with try-cache
+- Wrap `pendingResult.finish()` in PushBroadcastReceiver in try/catch to prevent crash.
 
 ## 7.12.4
 

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -7,8 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-sdk_version=7.12.4
-sdk_version_code=71204
+sdk_version=7.12.5
+sdk_version_code=71205
 sdk_platform=Android
 android.useAndroidX=true
 android.enableJetifier=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/PushBroadcastReceiver.java
@@ -551,7 +551,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 Notification notification = this.builder.build();
                 PushBroadcastReceiver.this.showNotification(this.context, this.pushMessage, notification);
 
-                pendingResult.finish();
+                finishPendingResultSafely(pendingResult);
                 return;
             }
 
@@ -563,7 +563,15 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                     .build();
 
             PushBroadcastReceiver.this.showNotification(this.context, this.pushMessage, notification);
+            finishPendingResultSafely(pendingResult);
+        }
+    }
+
+    private void finishPendingResultSafely(PendingResult pendingResult) {
+        try {
             pendingResult.finish();
+        } catch (IllegalStateException e) {
+            Optimobile.log(TAG, "PushBroadcastReceiver Broadcast already finished");
         }
     }
 


### PR DESCRIPTION
Hi!
Some days ago we had quite large crash spike for several minutes.

### Crash Logs

```
          Fatal Exception: java.lang.IllegalStateException: Broadcast already finished
       at android.content.BroadcastReceiver$PendingResult.sendFinished(BroadcastReceiver.java:316)
       at android.content.BroadcastReceiver$PendingResult.finish(BroadcastReceiver.java:292)
       at com.optimove.android.optimobile.PushBroadcastReceiver$LoadNotificationPicture.onPostExecute(PushBroadcastReceiver.java:557)
       at com.optimove.android.optimobile.PushBroadcastReceiver$LoadNotificationPicture.onPostExecute(PushBroadcastReceiver.java:482)
       at android.os.AsyncTask.finish(AsyncTask.java:773)
       at android.os.AsyncTask.-$$Nest$mfinish()
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:790)
       at android.os.Handler.dispatchMessageImpl(Handler.java:142)
       at android.os.Handler.dispatchMessage(Handler.java:125)
       at android.os.Looper.loopOnce(Looper.java:269)
       at android.os.Looper.loop(Looper.java:367)
       at android.app.ActivityThread.main(ActivityThread.java:9333)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
``` 

Upon investigation we are still unclear what could cause this spike on our side, but we found uncovered .finish() call in  PushBroadcastReceiver.
Although everything done correct **(1 Receiver - 1 PendingResult.finish() call)** - in some rare cases, and possibly on some vendors - this call to finish() could result in crash.

**So as suggestion - to wrap this finish call as a safety measure - implemented this Pull Request.**

### Description of Changes

Wrap pendingResult.finish() in PushBroadcastReceiver with try-cache

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [x] CHANGELOG.md
- [x] gradle.properties
- [ ] add links to newly created wiki pages to readme
- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
