### PR TITLE
AB#284384 - Fix: in-app delivered events underreported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
+## 7.13.2
+
+- Fix: in-app delivery underreporing.
+
 ## 7.13.1
 
 - Fix: Restored process-scoped storage for the in-app deep-link handler (pre-7.8.1 behaviour). Removed `WeakDeepLinkHandler` (7.8.1) and `LifecycleBoundDeepLinkHandler` (7.12.4). The handler is held until you call `setDeepLinkHandler(null)`. Fixes intermittent failures of in-app message deep-link buttons.
 
 **Recommended Integration:**
+
 - Register with `OptimoveInApp.setDeepLinkHandler(...)` from `Application`, not from a single `Activity`
 - Do **not** capture `Activity` in the handler; use the `context` passed to `InAppDeepLinkHandlerInterface.handle()`.
-- Call `setDeepLinkHandler(null)` only to explicitly unregister (e.g. logout). 
+- Call `setDeepLinkHandler(null)` only to explicitly unregister (e.g. logout).
 
 ## 7.13.0
 

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.13.1
-sdk_version_code=71301
+sdk_version=7.13.2
+sdk_version_code=71302
 
 sdk_platform=Android
 android.useAndroidX=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessageService.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/InAppMessageService.java
@@ -111,11 +111,9 @@ class InAppMessageService {
     }
 
     private static void trackDeliveredEvents(Context context, List<Integer> deliveredIds) {
-
-        JSONObject params = new JSONObject();
-
         for (Integer deliveredId : deliveredIds) {
             try {
+                JSONObject params = new JSONObject();
                 params.put("type", AnalyticsContract.MESSAGE_TYPE_IN_APP);
                 params.put("id", deliveredId);
 


### PR DESCRIPTION
### Description of Changes

Due to modifying same object ref, we may end up sending multiple delivery events with the same message id. 

This happens when multiple messages loaded at once (exaggerated by slower or absent silent tickles -- absent if no push), 1:N-1 get message id of message N. After message timestamps are updated, messages are synced again and some delivered may be reported then, but overall we are missing delivery events.

This affects metrics: delivery counts + rate and open rate, which is % of delivery.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number, and a migration guide in wiki / README.md

Bump versions in:

- [x] CHANGELOG.md
- [x] gradle.properties
- [ ] add links to newly created wiki pages to readme
- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

_T&T Only_

- [ ] Init SDK with only optimove credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

_Mobile Only_

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

_Deferred Deep Links_

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

_Combined_

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release Procedure

- [ ] Squash and merge `dev` to `master`
- [ ] Delete branch once merged
