### PR TITLE
AB#289456 - OverlayMessaging tweaks

### DIFF
--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.kt
@@ -26,7 +26,7 @@ class MyApplication : Application() {
                 .enableEmbeddedMessaging("embedded_config_string")
                 .setPushSmallIconId(R.drawable.small_icon)
                 .setPushAccentColor(Color.parseColor("#FF0000"))
-                .enableOverlayMessaging(1.0)
+                .enableOverlayMessaging(1)
                 .build()
         } else {
             OptimoveConfig.Builder(
@@ -36,7 +36,7 @@ class MyApplication : Application() {
                 .enableInAppMessaging(OptimoveConfig.InAppConsentStrategy.AUTO_ENROLL)
                 .setPushSmallIconId(R.drawable.small_icon)
                 .setPushAccentColor(Color.parseColor("#FF0000"))
-                .enableOverlayMessaging(1.0)
+                .enableOverlayMessaging(1)
                 .build()
         }
 

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.kt
@@ -26,7 +26,7 @@ class MyApplication : Application() {
                 .enableEmbeddedMessaging("embedded_config_string")
                 .setPushSmallIconId(R.drawable.small_icon)
                 .setPushAccentColor(Color.parseColor("#FF0000"))
-                .enableOverlayMessaging(1)
+                .enableOverlayMessaging(1.0)
                 .build()
         } else {
             OptimoveConfig.Builder(
@@ -36,7 +36,7 @@ class MyApplication : Application() {
                 .enableInAppMessaging(OptimoveConfig.InAppConsentStrategy.AUTO_ENROLL)
                 .setPushSmallIconId(R.drawable.small_icon)
                 .setPushAccentColor(Color.parseColor("#FF0000"))
-                .enableOverlayMessaging(1)
+                .enableOverlayMessaging(1.0)
                 .build()
         }
 

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.15.2
-sdk_version_code=71500
+sdk_version=7.16.0
+sdk_version_code=71600
 
 sdk_platform=Android
 android.useAndroidX=true

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -589,6 +589,10 @@ public final class OptimoveConfig {
             return this;
         }
 
+        /**
+         * @param sessionLengthHours length of an overlay messaging session, in whole hours. Minimum 1.
+         * @see #enableOverlayMessagingMinutes(int) to set a session length below 1 hour.
+         */
         public Builder enableOverlayMessaging(int sessionLengthHours) {
             if (sessionLengthHours <= 0) {
                 throw new IllegalArgumentException("OverlayMessaging: sessionLengthHours must be greater than 0");
@@ -600,6 +604,9 @@ public final class OptimoveConfig {
             return this;
         }
 
+        /**
+         * @param sessionLengthMinutes length of an overlay messaging session, in whole minutes. Minimum 15.
+         */
         public Builder enableOverlayMessagingMinutes(int sessionLengthMinutes) {
             if (sessionLengthMinutes < 15) {
                 throw new IllegalArgumentException("OverlayMessaging: sessionLengthMinutes must be at least 15");

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -74,7 +74,7 @@ public final class OptimoveConfig {
     private @Nullable EmbeddedMessagingConfig embeddedMessagingConfig;
 
     private boolean overlayMessagingEnabled;
-    private @Nullable Double overlayMessagingSessionLengthHours;
+    private @Nullable Integer overlayMessagingSessionLengthMinutes;
 
     public enum InAppConsentStrategy {
         AUTO_ENROLL,
@@ -423,8 +423,8 @@ public final class OptimoveConfig {
         return this.overlayMessagingEnabled;
     }
 
-    public double getOverlayMessagingSessionLengthHours() {
-        return this.overlayMessagingSessionLengthHours;
+    public int getOverlayMessagingSessionLengthMinutes() {
+        return this.overlayMessagingSessionLengthMinutes;
     }
 
     private boolean hasFinishedInitialisation() {
@@ -486,7 +486,7 @@ public final class OptimoveConfig {
 
         private @Nullable LogLevel minLogLevel;
 
-        private @Nullable Double overlayMessagingSessionLengthHours;
+        private @Nullable Integer overlayMessagingSessionLengthMinutes;
 
         /**
          * @deprecated Use {@link Builder#Builder(FeatureSet)} instead
@@ -589,14 +589,25 @@ public final class OptimoveConfig {
             return this;
         }
 
-        public Builder enableOverlayMessaging(double sessionLengthHours) {
-            if (sessionLengthHours < 0.25) {
-                throw new IllegalArgumentException("OverlayMessaging: sessionLengthHours must be at least 0.25 (15 minutes)");
+        public Builder enableOverlayMessaging(int sessionLengthHours) {
+            if (sessionLengthHours <= 0) {
+                throw new IllegalArgumentException("OverlayMessaging: sessionLengthHours must be greater than 0");
             }
             if (!this.featureSet.has(FeatureSet.Feature.OPTIMOBILE)) {
                 throw new IllegalArgumentException("OverlayMessaging: optimobile feature required");
             }
-            this.overlayMessagingSessionLengthHours = sessionLengthHours;
+            this.overlayMessagingSessionLengthMinutes = sessionLengthHours * 60;
+            return this;
+        }
+
+        public Builder enableOverlayMessagingMinutes(int sessionLengthMinutes) {
+            if (sessionLengthMinutes < 15) {
+                throw new IllegalArgumentException("OverlayMessaging: sessionLengthMinutes must be at least 15");
+            }
+            if (!this.featureSet.has(FeatureSet.Feature.OPTIMOBILE)) {
+                throw new IllegalArgumentException("OverlayMessaging: optimobile feature required");
+            }
+            this.overlayMessagingSessionLengthMinutes = sessionLengthMinutes;
             return this;
         }
 
@@ -690,8 +701,8 @@ public final class OptimoveConfig {
 
             newConfig.setMinLogLevel(this.minLogLevel);
 
-            newConfig.overlayMessagingEnabled = this.overlayMessagingSessionLengthHours != null;
-            newConfig.overlayMessagingSessionLengthHours = this.overlayMessagingSessionLengthHours;
+            newConfig.overlayMessagingEnabled = this.overlayMessagingSessionLengthMinutes != null;
+            newConfig.overlayMessagingSessionLengthMinutes = this.overlayMessagingSessionLengthMinutes;
 
             return newConfig;
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -148,6 +149,25 @@ public final class OptimoveConfig {
 
         boolean isEmpty() {
             return features.isEmpty();
+        }
+    }
+
+    /**
+     * Length of an overlay messaging session, expressed as a duration + unit pair.
+     *
+     * @see Builder#enableOverlayMessaging(OverlaySessionSettings)
+     */
+    public static final class OverlaySessionSettings {
+        private final long duration;
+        private final TimeUnit durationUnit;
+
+        public OverlaySessionSettings(long duration, @NonNull TimeUnit durationUnit) {
+            this.duration = duration;
+            this.durationUnit = durationUnit;
+        }
+
+        long durationInMinutes() {
+            return durationUnit.toMinutes(duration);
         }
     }
 
@@ -591,7 +611,7 @@ public final class OptimoveConfig {
 
         /**
          * @param sessionLengthHours length of an overlay messaging session, in whole hours. Minimum 1.
-         * @see #enableOverlayMessagingMinutes(int) to set a session length below 1 hour.
+         * @see #enableOverlayMessaging(OverlaySessionSettings) to set a session length below 1 hour.
          */
         public Builder enableOverlayMessaging(int sessionLengthHours) {
             if (sessionLengthHours <= 0) {
@@ -605,16 +625,17 @@ public final class OptimoveConfig {
         }
 
         /**
-         * @param sessionLengthMinutes length of an overlay messaging session, in whole minutes. Minimum 15.
+         * @param sessionSettings length of an overlay messaging session. Minimum 15 minutes.
          */
-        public Builder enableOverlayMessagingMinutes(int sessionLengthMinutes) {
+        public Builder enableOverlayMessaging(@NonNull OverlaySessionSettings sessionSettings) {
+            long sessionLengthMinutes = sessionSettings.durationInMinutes();
             if (sessionLengthMinutes < 15) {
-                throw new IllegalArgumentException("OverlayMessaging: sessionLengthMinutes must be at least 15");
+                throw new IllegalArgumentException("OverlayMessaging: session length must be at least 15 minutes");
             }
             if (!this.featureSet.has(FeatureSet.Feature.OPTIMOBILE)) {
                 throw new IllegalArgumentException("OverlayMessaging: optimobile feature required");
             }
-            this.overlayMessagingSessionLengthMinutes = sessionLengthMinutes;
+            this.overlayMessagingSessionLengthMinutes = (int) sessionLengthMinutes;
             return this;
         }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -153,21 +153,21 @@ public final class OptimoveConfig {
     }
 
     /**
-     * Length of an overlay messaging session, expressed as a duration + unit pair.
+     * Settings for overlay messaging, currently just the session duration.
      *
-     * @see Builder#enableOverlayMessaging(OverlaySessionSettings)
+     * @see Builder#enableOverlayMessaging(OverlaySettings)
      */
-    public static final class OverlaySessionSettings {
-        private final long duration;
-        private final TimeUnit durationUnit;
+    public static final class OverlaySettings {
+        private final long sessionDuration;
+        private final TimeUnit sessionDurationUnit;
 
-        public OverlaySessionSettings(long duration, @NonNull TimeUnit durationUnit) {
-            this.duration = duration;
-            this.durationUnit = durationUnit;
+        public OverlaySettings(long sessionDuration, @NonNull TimeUnit sessionDurationUnit) {
+            this.sessionDuration = sessionDuration;
+            this.sessionDurationUnit = sessionDurationUnit;
         }
 
-        long durationInMinutes() {
-            return durationUnit.toMinutes(duration);
+        long sessionDurationInMinutes() {
+            return sessionDurationUnit.toMinutes(sessionDuration);
         }
     }
 
@@ -611,7 +611,7 @@ public final class OptimoveConfig {
 
         /**
          * @param sessionLengthHours length of an overlay messaging session, in whole hours. Minimum 1.
-         * @see #enableOverlayMessaging(OverlaySessionSettings) to set a session length below 1 hour.
+         * @see #enableOverlayMessaging(OverlaySettings) to set a session length below 1 hour.
          */
         public Builder enableOverlayMessaging(int sessionLengthHours) {
             if (sessionLengthHours <= 0) {
@@ -625,10 +625,10 @@ public final class OptimoveConfig {
         }
 
         /**
-         * @param sessionSettings length of an overlay messaging session. Minimum 15 minutes.
+         * @param overlaySettings overlay messaging settings. Session length must be at least 15 minutes.
          */
-        public Builder enableOverlayMessaging(@NonNull OverlaySessionSettings sessionSettings) {
-            long sessionLengthMinutes = sessionSettings.durationInMinutes();
+        public Builder enableOverlayMessaging(@NonNull OverlaySettings overlaySettings) {
+            long sessionLengthMinutes = overlaySettings.sessionDurationInMinutes();
             if (sessionLengthMinutes < 15) {
                 throw new IllegalArgumentException("OverlayMessaging: session length must be at least 15 minutes");
             }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/OptimoveConfig.java
@@ -74,7 +74,7 @@ public final class OptimoveConfig {
     private @Nullable EmbeddedMessagingConfig embeddedMessagingConfig;
 
     private boolean overlayMessagingEnabled;
-    private @Nullable Integer overlayMessagingSessionLengthHours;
+    private @Nullable Double overlayMessagingSessionLengthHours;
 
     public enum InAppConsentStrategy {
         AUTO_ENROLL,
@@ -423,7 +423,7 @@ public final class OptimoveConfig {
         return this.overlayMessagingEnabled;
     }
 
-    public int getOverlayMessagingSessionLengthHours() {
+    public double getOverlayMessagingSessionLengthHours() {
         return this.overlayMessagingSessionLengthHours;
     }
 
@@ -486,7 +486,7 @@ public final class OptimoveConfig {
 
         private @Nullable LogLevel minLogLevel;
 
-        private @Nullable Integer overlayMessagingSessionLengthHours;
+        private @Nullable Double overlayMessagingSessionLengthHours;
 
         /**
          * @deprecated Use {@link Builder#Builder(FeatureSet)} instead
@@ -589,9 +589,9 @@ public final class OptimoveConfig {
             return this;
         }
 
-        public Builder enableOverlayMessaging(int sessionLengthHours) {
-            if (sessionLengthHours <= 0) {
-                throw new IllegalArgumentException("OverlayMessaging: sessionLengthHours must be greater than 0");
+        public Builder enableOverlayMessaging(double sessionLengthHours) {
+            if (sessionLengthHours < 0.25) {
+                throw new IllegalArgumentException("OverlayMessaging: sessionLengthHours must be at least 0.25 (15 minutes)");
             }
             if (!this.featureSet.has(FeatureSet.Feature.OPTIMOBILE)) {
                 throw new IllegalArgumentException("OverlayMessaging: optimobile feature required");

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/Optimobile.java
@@ -250,6 +250,10 @@ public final class Optimobile {
 
         if (isNewUserIdentifier) {
             OptimoveInApp.getInstance().handleInAppUserChange(context, Optimove.getConfig());
+
+            if (Optimove.getConfig().isOverlayMessagingEnabled()) {
+                OptimoveOverlayMessaging.getInstance().resetSession();
+            }
         }
     }
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveOverlayMessaging.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveOverlayMessaging.java
@@ -17,7 +17,7 @@ public class OptimoveOverlayMessaging {
     private OverlayMessagingSessionManager sessionManager;
     private final OverlayMessagingManager manager;
     private final Application application;
-    private final long sessionLengthHours;
+    private final double sessionLengthHours;
 
     public interface OverlayMessagingInterceptorCallback {
         @UiThread
@@ -39,7 +39,7 @@ public class OptimoveOverlayMessaging {
         }
     }
 
-    private OptimoveOverlayMessaging(@NonNull Application application, long sessionLengthHours) {
+    private OptimoveOverlayMessaging(@NonNull Application application, double sessionLengthHours) {
         this.application = application;
         this.sessionLengthHours = sessionLengthHours;
         this.manager = new OverlayMessagingManager(application);

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveOverlayMessaging.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OptimoveOverlayMessaging.java
@@ -17,7 +17,7 @@ public class OptimoveOverlayMessaging {
     private OverlayMessagingSessionManager sessionManager;
     private final OverlayMessagingManager manager;
     private final Application application;
-    private final double sessionLengthHours;
+    private final long sessionLengthMinutes;
 
     public interface OverlayMessagingInterceptorCallback {
         @UiThread
@@ -39,16 +39,16 @@ public class OptimoveOverlayMessaging {
         }
     }
 
-    private OptimoveOverlayMessaging(@NonNull Application application, double sessionLengthHours) {
+    private OptimoveOverlayMessaging(@NonNull Application application, long sessionLengthMinutes) {
         this.application = application;
-        this.sessionLengthHours = sessionLengthHours;
+        this.sessionLengthMinutes = sessionLengthMinutes;
         this.manager = new OverlayMessagingManager(application);
     }
 
     private void startSessionManager() {
         OverlayMessagingSessionManager.Listener sessionListener = () ->
                 manager.onTriggerReceived(OverlayMessagingMessage.MessageType.SESSION);
-        this.sessionManager = new OverlayMessagingSessionManager(application, sessionLengthHours, sessionListener);
+        this.sessionManager = new OverlayMessagingSessionManager(application, sessionLengthMinutes, sessionListener);
     }
 
     //==============================================================================================
@@ -87,7 +87,7 @@ public class OptimoveOverlayMessaging {
     }
 
     static void initialize(@NonNull Application application, @NonNull OptimoveConfig config) {
-        shared = new OptimoveOverlayMessaging(application, config.getOverlayMessagingSessionLengthHours());
+        shared = new OptimoveOverlayMessaging(application, config.getOverlayMessagingSessionLengthMinutes());
         if (!config.usesDelayedOptimobileConfiguration()) {
             shared.startSessionManager();
         }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OverlayMessagingSessionManager.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OverlayMessagingSessionManager.java
@@ -34,9 +34,9 @@ class OverlayMessagingSessionManager implements AppStateWatcher.AppStateChangedL
         }
     };
 
-    OverlayMessagingSessionManager(@NonNull Context context, long sessionLengthHours, @NonNull Listener listener) {
+    OverlayMessagingSessionManager(@NonNull Context context, double sessionLengthHours, @NonNull Listener listener) {
         this.handler = new Handler(Looper.getMainLooper());
-        this.sessionLengthMs = sessionLengthHours * 3_600_000L;
+        this.sessionLengthMs = Math.round(sessionLengthHours * 3_600_000L);
         this.listener = listener;
         this.prefs = context.getApplicationContext().getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
 

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OverlayMessagingSessionManager.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/optimobile/OverlayMessagingSessionManager.java
@@ -34,9 +34,9 @@ class OverlayMessagingSessionManager implements AppStateWatcher.AppStateChangedL
         }
     };
 
-    OverlayMessagingSessionManager(@NonNull Context context, double sessionLengthHours, @NonNull Listener listener) {
+    OverlayMessagingSessionManager(@NonNull Context context, long sessionLengthMinutes, @NonNull Listener listener) {
         this.handler = new Handler(Looper.getMainLooper());
-        this.sessionLengthMs = Math.round(sessionLengthHours * 3_600_000L);
+        this.sessionLengthMs = sessionLengthMinutes * 60_000L;
         this.listener = listener;
         this.prefs = context.getApplicationContext().getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
 


### PR DESCRIPTION

1. Drop min Overlay session length from 1h to 15 minutes
```
.enableOverlayMessaging(OptimoveConfig.OverlaySettings(15, TimeUnit.MINUTES))
```

Rule out against builder pattern for overlay settings, we dont expect amount of setting to grow significantly --> mb an overkill. API is different from swift where arg labels are idiomatic.

`enableOverlayMessaging(int sessionLengthHours)` is unchanged for backwards compatibility. Later we can deprecate it. 


2. Reset overlay session at user login. Note, this happens on login, but not logout:
- to match web sdk
- logged out users cannot receive scheduled campaigns

Counterpart for https://github.com/optimove-tech/Optimove-SDK-iOS/pull/142
