### PR TITLE
AB#287059 feat: add adact support in sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## 7.16.0
+
+- Added Adact campaign support to `GamifyWidgetSDK`: `initialize(widgetUrl, adactUrl)`, `openAdactCampaign(activity, OpenAdactParams)`, `closeAdactCampaign()`, and `buildAdactCampaignUrl`. Opens `{adactUrl}/embedded/{campaignId}` with optional `cid` and `customerIdToken` query params (same contract as the Web SDK). Adact does not use the loyalty READY→INIT handshake.
+
+
 ## 7.15.2
 
 - Fixed crash on MIUI/HyperOS devices running Android 16 when tapping push notifications (SecurityException in PushOpenInvisibleActivity caused by Android 16 Intent Redirect Hardening). The MIUI launch intent is now dispatched via PendingIntent.send() rather than startActivity() on an unparceled nested intent.

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/GamifyWidgetActivity.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/GamifyWidgetActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.optimove.android.gamifywidgetsdk.GamifyWidgetSDK
+import com.optimove.android.gamifywidgetsdk.OpenAdactParams
 import com.optimove.android.optimovemobilesdk.ui.GamifyWidgetScreen
 import com.optimove.android.optimovemobilesdk.ui.theme.AppTheme
 
@@ -25,6 +26,10 @@ class GamifyWidgetActivity : AppCompatActivity() {
     private var tenant by mutableStateOf("")
     private var userId by mutableStateOf("")
     private var env by mutableStateOf(GamifyEnv.DEV)
+    private var adactUrl by mutableStateOf(DEFAULT_ADACT_URL)
+    private var campaignId by mutableStateOf("")
+    private var cid by mutableStateOf("")
+    private var adactToken by mutableStateOf("")
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,6 +38,10 @@ class GamifyWidgetActivity : AppCompatActivity() {
         tenant = prefs.getString(KEY_TENANT, "") ?: ""
         userId = prefs.getString(KEY_USER_ID, "") ?: ""
         env = enumValues<GamifyEnv>().find { it.name == prefs.getString(KEY_ENV, null) } ?: GamifyEnv.DEV
+        adactUrl = prefs.getString(KEY_ADACT_URL, DEFAULT_ADACT_URL) ?: DEFAULT_ADACT_URL
+        campaignId = prefs.getString(KEY_CAMPAIGN_ID, "") ?: ""
+        cid = prefs.getString(KEY_CID, "") ?: ""
+        adactToken = prefs.getString(KEY_ADACT_TOKEN, "") ?: ""
 
         setContent {
             AppTheme {
@@ -40,10 +49,20 @@ class GamifyWidgetActivity : AppCompatActivity() {
                     tenant = tenant,
                     userId = userId,
                     env = env,
+                    adactUrl = adactUrl,
+                    campaignId = campaignId,
+                    cid = cid,
+                    adactToken = adactToken,
                     onTenantChange = { tenant = it; save() },
                     onWidgetIdChange = { userId = it; save() },
                     onEnvChange = { env = it; save() },
-                    onOpenWidget = ::openWidget
+                    onAdactUrlChange = { adactUrl = it; save() },
+                    onCampaignIdChange = { campaignId = it; save() },
+                    onCidChange = { cid = it; save() },
+                    onAdactTokenChange = { adactToken = it; save() },
+                    onOpenWidget = ::openWidget,
+                    onOpenAdactCampaign = ::openAdactCampaign,
+                    onCloseAdactCampaign = ::closeAdactCampaign
                 )
             }
         }
@@ -54,13 +73,46 @@ class GamifyWidgetActivity : AppCompatActivity() {
             .putString(KEY_TENANT, tenant)
             .putString(KEY_USER_ID, userId)
             .putString(KEY_ENV, env.name)
+            .putString(KEY_ADACT_URL, adactUrl)
+            .putString(KEY_CAMPAIGN_ID, campaignId)
+            .putString(KEY_CID, cid)
+            .putString(KEY_ADACT_TOKEN, adactToken)
             .apply()
     }
 
+    private fun ensureInitialized() {
+        val widgetUrl = if (tenant.isNotBlank() && userId.isNotBlank()) {
+            "${env.baseUrl}/$tenant/$userId"
+        } else {
+            null
+        }
+        GamifyWidgetSDK.initialize(widgetUrl, adactUrl.ifBlank { null })
+    }
+
     private fun openWidget() {
-        val widgetUrl = "${env.baseUrl}/$tenant/$userId"
-        GamifyWidgetSDK.initialize(widgetUrl)
+        ensureInitialized()
         GamifyWidgetSDK.getInstance().open(this, userId, null)
+    }
+
+    private fun openAdactCampaign() {
+        ensureInitialized()
+        val id = campaignId.trim().toIntOrNull() ?: return
+        GamifyWidgetSDK.getInstance().openAdactCampaign(
+            this,
+            OpenAdactParams(
+                id,
+                cid.ifBlank { null },
+                adactToken.ifBlank { null }
+            )
+        )
+    }
+
+    private fun closeAdactCampaign() {
+        try {
+            GamifyWidgetSDK.getInstance().closeAdactCampaign()
+        } catch (_: IllegalStateException) {
+            // SDK not initialized yet
+        }
     }
 
     companion object {
@@ -68,5 +120,10 @@ class GamifyWidgetActivity : AppCompatActivity() {
         private const val KEY_TENANT = "tenant"
         private const val KEY_USER_ID = "user_id"
         private const val KEY_ENV = "env"
+        private const val KEY_ADACT_URL = "adact_url"
+        private const val KEY_CAMPAIGN_ID = "campaign_id"
+        private const val KEY_CID = "cid"
+        private const val KEY_ADACT_TOKEN = "adact_token"
+        private const val DEFAULT_ADACT_URL = "https://adact-campaign-dev.optimove.net/"
     }
 }

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/MyApplication.kt
@@ -15,15 +15,18 @@ class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // Default true so first launch doesn't crash on placeholder credentials.
+        // Toggle "Delayed Initialization" in the demo UI, then restart to switch modes.
         val useDelayed = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .getBoolean(KEY_DELAYED_INIT, false)
+            .getBoolean(KEY_DELAYED_INIT, true)
 
         val config = if (useDelayed) {
+            // No placeholder embedded-messaging / Optimove creds — those must be real base64
+            // configs or the app crashes on startup. Gamify/Adact work without them.
             OptimoveConfig.Builder(
                 OptimoveConfig.FeatureSet().withOptimove().withOptimobile()
             )
                 .enableInAppMessaging(OptimoveConfig.InAppConsentStrategy.AUTO_ENROLL)
-                .enableEmbeddedMessaging("embedded_config_string")
                 .setPushSmallIconId(R.drawable.small_icon)
                 .setPushAccentColor(Color.parseColor("#FF0000"))
                 .enableOverlayMessaging(1)

--- a/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/ui/GamifyWidgetScreen.kt
+++ b/OptimoveSDK/app/src/main/java/com/optimove/android/optimovemobilesdk/ui/GamifyWidgetScreen.kt
@@ -3,12 +3,15 @@ package com.optimove.android.optimovemobilesdk.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -21,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.optimove.android.optimovemobilesdk.GamifyEnv
-import androidx.compose.foundation.layout.Row
 
 private val CardShape = RoundedCornerShape(12.dp)
 private val SectionPadding = 16.dp
@@ -31,15 +33,26 @@ fun GamifyWidgetScreen(
     tenant: String,
     userId: String,
     env: GamifyEnv,
+    adactUrl: String,
+    campaignId: String,
+    cid: String,
+    adactToken: String,
     onTenantChange: (String) -> Unit,
     onWidgetIdChange: (String) -> Unit,
     onEnvChange: (GamifyEnv) -> Unit,
-    onOpenWidget: () -> Unit
+    onAdactUrlChange: (String) -> Unit,
+    onCampaignIdChange: (String) -> Unit,
+    onCidChange: (String) -> Unit,
+    onAdactTokenChange: (String) -> Unit,
+    onOpenWidget: () -> Unit,
+    onOpenAdactCampaign: () -> Unit,
+    onCloseAdactCampaign: () -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)
+            .verticalScroll(rememberScrollState())
             .padding(SectionPadding)
     ) {
         Text(
@@ -65,11 +78,7 @@ fun GamifyWidgetScreen(
                     label = { Text("Tenant") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        focusedLabelColor = MaterialTheme.colorScheme.primary,
-                        cursorColor = MaterialTheme.colorScheme.primary
-                    )
+                    colors = fieldColors()
                 )
                 OutlinedTextField(
                     value = userId,
@@ -77,11 +86,7 @@ fun GamifyWidgetScreen(
                     label = { Text("User ID") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        focusedLabelColor = MaterialTheme.colorScheme.primary,
-                        cursorColor = MaterialTheme.colorScheme.primary
-                    )
+                    colors = fieldColors()
                 )
                 Text(
                     "Environment",
@@ -121,5 +126,82 @@ fun GamifyWidgetScreen(
         ) {
             Text("Open Widget")
         }
+
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            "Adact Campaign",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = CardShape,
+            color = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Column(
+                modifier = Modifier.padding(SectionPadding),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedTextField(
+                    value = adactUrl,
+                    onValueChange = onAdactUrlChange,
+                    label = { Text("Adact URL") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = fieldColors()
+                )
+                OutlinedTextField(
+                    value = campaignId,
+                    onValueChange = onCampaignIdChange,
+                    label = { Text("Campaign ID") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = fieldColors()
+                )
+                OutlinedTextField(
+                    value = cid,
+                    onValueChange = onCidChange,
+                    label = { Text("CID (optional)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = fieldColors()
+                )
+                OutlinedTextField(
+                    value = adactToken,
+                    onValueChange = onAdactTokenChange,
+                    label = { Text("Token (optional)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = fieldColors()
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onOpenAdactCampaign,
+            enabled = adactUrl.isNotBlank() && campaignId.isNotBlank(),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(10.dp)
+        ) {
+            Text("Open Adact Campaign")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedButton(
+            onClick = onCloseAdactCampaign,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(10.dp)
+        ) {
+            Text("Close Adact Campaign")
+        }
     }
 }
+
+@Composable
+private fun fieldColors() = OutlinedTextFieldDefaults.colors(
+    focusedBorderColor = MaterialTheme.colorScheme.primary,
+    focusedLabelColor = MaterialTheme.colorScheme.primary,
+    cursorColor = MaterialTheme.colorScheme.primary
+)

--- a/OptimoveSDK/gradle.properties
+++ b/OptimoveSDK/gradle.properties
@@ -8,8 +8,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-sdk_version=7.15.2
-sdk_version_code=71500
+sdk_version=7.16.0
+sdk_version_code=71600
 
 sdk_platform=Android
 android.useAndroidX=true

--- a/OptimoveSDK/optimove-sdk/optimove-proguard-rules.pro
+++ b/OptimoveSDK/optimove-sdk/optimove-proguard-rules.pro
@@ -1,6 +1,7 @@
 -keep class com.optimove.android.main.sdk_configs.** { <fields>; }
 -keep class com.optimove.android.optistream.OptistreamEvent { <fields>; }
 -keep class com.optimove.android.gamifywidgetsdk.GamifyWidgetSDK { public *; }
+-keep class com.optimove.android.gamifywidgetsdk.OpenAdactParams { public *; }
 -keepclassmembers class com.optimove.android.gamifywidgetsdk.AndroidBridge {
     @android.webkit.JavascriptInterface <methods>;
 }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/AndroidBridge.java
@@ -3,23 +3,27 @@ package com.optimove.android.gamifywidgetsdk;
 import android.util.Log;
 import android.webkit.JavascriptInterface;
 
+import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * Native bridge exposed to the widget's JavaScript as `window.AndroidBridge`.
+ * Native bridge exposed to the widget's JavaScript as {@code window.AndroidBridge}.
  *
- * The widget calls:
- *   window.AndroidBridge.closeWidget()        — to dismiss the dialog
- *   window.AndroidBridge.receiveMessage(json) — generic widget → SDK messages,
- *       including the READY handshake (type = "READY")
+ * <p>The widget calls:
+ * <ul>
+ *   <li>{@code window.AndroidBridge.closeWidget()} — dismiss the dialog</li>
+ *   <li>{@code window.AndroidBridge.receiveMessage(json)} — widget → SDK messages,
+ *       including READY (loyalty handshake) and CLOSE</li>
+ * </ul>
  */
 class AndroidBridge {
 
     private final Runnable onClose;
-    private final Runnable onReady;
+    @Nullable private final Runnable onReady;
 
-    AndroidBridge(Runnable onClose, Runnable onReady) {
+    AndroidBridge(Runnable onClose, @Nullable Runnable onReady) {
         this.onClose = onClose;
         this.onReady = onReady;
     }
@@ -32,8 +36,13 @@ class AndroidBridge {
     @JavascriptInterface
     public void receiveMessage(String json) {
         try {
-            if ("READY".equals(new JSONObject(json).getString("type"))) {
-                onReady.run();
+            String type = new JSONObject(json).getString("type");
+            if ("READY".equals(type)) {
+                if (onReady != null) {
+                    onReady.run();
+                }
+            } else if ("CLOSE".equals(type)) {
+                onClose.run();
             }
         } catch (JSONException e) {
             Log.d(GamifyWidgetSDK.TAG, "Incorrect message format: " + json);

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDK.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDK.java
@@ -1,16 +1,26 @@
 package com.optimove.android.gamifywidgetsdk;
 
 import android.app.Activity;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
- * Entry point for the Gamify Widget SDK.
+ * Entry point for the Gamify Widget SDK (loyalty + Adact).
  *
- * Usage:
+ * <p>Usage (loyalty):
+ * <pre>
  *   GamifyWidgetSDK.initialize("https://your-widget.example.com");
  *   GamifyWidgetSDK.getInstance().open(activity, "u123", "auth-token");
+ * </pre>
+ *
+ * <p>Usage (Adact — {@code adactUrl} from onboarding / retrieval service):
+ * <pre>
+ *   GamifyWidgetSDK.initialize(widgetUrl, "https://adact-campaign.example.com/");
+ *   GamifyWidgetSDK.getInstance().openAdactCampaign(activity,
+ *       new OpenAdactParams(179, "cid", "token"));
+ * </pre>
  */
 public class GamifyWidgetSDK {
 
@@ -18,8 +28,10 @@ public class GamifyWidgetSDK {
 
     private static GamifyWidgetSDK shared;
 
-    private String widgetUrl;
-    private WidgetDialog currentDialog;
+    @Nullable private String widgetUrl;
+    @Nullable private String adactUrl;
+    @Nullable private WidgetDialog loyaltyDialog;
+    @Nullable private WidgetDialog adactDialog;
 
     public static GamifyWidgetSDK getInstance() {
         if (shared == null) {
@@ -29,8 +41,23 @@ public class GamifyWidgetSDK {
     }
 
     public static void initialize(@NonNull String widgetUrl) {
+        initialize(widgetUrl, null);
+    }
+
+    /**
+     * @param widgetUrl loyalty widget base URL (may be null/blank if only Adact is used)
+     * @param adactUrl  Adact campaign host from config (trailing slash optional);
+     *                  region-correct URL is supplied by onboarding / retrieval service
+     */
+    public static void initialize(@Nullable String widgetUrl, @Nullable String adactUrl) {
         shared = new GamifyWidgetSDK();
         shared.widgetUrl = widgetUrl;
+        shared.adactUrl = normalizeBaseUrl(adactUrl);
+    }
+
+    @NonNull
+    public String getAdactUrl() {
+        return adactUrl != null ? adactUrl + "/" : "";
     }
 
     public void open(@NonNull Activity activity) {
@@ -38,10 +65,87 @@ public class GamifyWidgetSDK {
     }
 
     public void open(@NonNull Activity activity, @Nullable String userId, @Nullable String token) {
-        if (currentDialog != null) {
+        if (widgetUrl == null || widgetUrl.isEmpty()) {
             return;
         }
-        currentDialog = new WidgetDialog(activity, widgetUrl, userId, token, () -> currentDialog = null);
-        currentDialog.show();
+        if (loyaltyDialog != null) {
+            return;
+        }
+        // Both surfaces are fullscreen overlays on Android — only one at a time.
+        closeAdactCampaign();
+        loyaltyDialog = new WidgetDialog(activity, widgetUrl, userId, token, () -> loyaltyDialog = null);
+        loyaltyDialog.show();
+    }
+
+    /**
+     * Opens an Adact embedded campaign overlay.
+     * Does not perform the loyalty READY→INIT handshake; identity is passed via URL query params.
+     */
+    public void openAdactCampaign(@NonNull Activity activity, @NonNull OpenAdactParams params) {
+        String campaignUrl = buildAdactCampaignUrl(params);
+        if (campaignUrl.isEmpty()) {
+            return;
+        }
+        if (adactDialog != null) {
+            return;
+        }
+        closeWidget();
+        adactDialog = new WidgetDialog(
+                activity,
+                campaignUrl,
+                null,
+                null,
+                false,
+                () -> adactDialog = null);
+        adactDialog.show();
+    }
+
+    /**
+     * Builds {@code {adactUrl}/embedded/{campaignId}?cid=&customerIdToken=}.
+     * Returns empty string when {@code adactUrl} or {@code campaignId} is missing, or URL is not HTTPS.
+     */
+    @NonNull
+    public String buildAdactCampaignUrl(@NonNull OpenAdactParams params) {
+        if (adactUrl == null || adactUrl.isEmpty() || params.campaignId == null) {
+            return "";
+        }
+
+        try {
+            Uri uri = Uri.parse(adactUrl + "/embedded/" + params.campaignId);
+            if (!"https".equalsIgnoreCase(uri.getScheme())) {
+                return "";
+            }
+
+            Uri.Builder builder = uri.buildUpon();
+            if (params.cid != null && !params.cid.isEmpty()) {
+                builder.appendQueryParameter("cid", params.cid);
+            }
+            if (params.token != null && !params.token.isEmpty()) {
+                builder.appendQueryParameter("customerIdToken", params.token);
+            }
+            return builder.build().toString();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    public void closeWidget() {
+        if (loyaltyDialog != null) {
+            loyaltyDialog.dismiss();
+        }
+    }
+
+    public void closeAdactCampaign() {
+        if (adactDialog != null) {
+            adactDialog.dismiss();
+        }
+    }
+
+    @Nullable
+    static String normalizeBaseUrl(@Nullable String url) {
+        if (url == null || url.isEmpty()) {
+            return null;
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 }

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/OpenAdactParams.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/OpenAdactParams.java
@@ -1,0 +1,27 @@
+package com.optimove.android.gamifywidgetsdk;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Parameters for opening an Adact embedded campaign.
+ *
+ * <p>Maps to the Web SDK {@code openAdactCampaign} contract:
+ * {@code {adactUrl}/embedded/{campaignId}?cid=&customerIdToken=}
+ */
+public class OpenAdactParams {
+
+    @Nullable public Integer campaignId;
+    @Nullable public String cid;
+    @Nullable public String token;
+
+    public OpenAdactParams() {
+    }
+
+    public OpenAdactParams(@Nullable Integer campaignId,
+                           @Nullable String cid,
+                           @Nullable String token) {
+        this.campaignId = campaignId;
+        this.cid = cid;
+        this.token = token;
+    }
+}

--- a/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/WidgetDialog.java
+++ b/OptimoveSDK/optimove-sdk/src/main/java/com/optimove/android/gamifywidgetsdk/WidgetDialog.java
@@ -30,6 +30,7 @@ class WidgetDialog {
     private final String widgetUrl;
     @Nullable private final String userId;
     @Nullable private final String token;
+    private final boolean enableInitHandshake;
     private final Runnable onDismissed;
     private final Dialog dialog;
 
@@ -37,16 +38,34 @@ class WidgetDialog {
     private ProgressBar progressBar;
     private TextView errorView;
 
+    /**
+     * Loyalty widget dialog — READY → INIT handshake with optional userId/token.
+     */
     @SuppressLint("InflateParams")
     WidgetDialog(@NonNull Activity activity,
                  @NonNull String widgetUrl,
                  @Nullable String userId,
                  @Nullable String token,
                  @NonNull Runnable onDismissed) {
+        this(activity, widgetUrl, userId, token, true, onDismissed);
+    }
+
+    /**
+     * Generic WebView dialog. Adact campaigns use {@code enableInitHandshake = false}
+     * (identity is passed via URL query params, not INIT).
+     */
+    @SuppressLint("InflateParams")
+    WidgetDialog(@NonNull Activity activity,
+                 @NonNull String widgetUrl,
+                 @Nullable String userId,
+                 @Nullable String token,
+                 boolean enableInitHandshake,
+                 @NonNull Runnable onDismissed) {
         this.activity = activity;
         this.widgetUrl = widgetUrl;
         this.userId = userId;
         this.token = token;
+        this.enableInitHandshake = enableInitHandshake;
         this.onDismissed = onDismissed;
         this.dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
 
@@ -71,10 +90,14 @@ class WidgetDialog {
         settings.setLoadWithOverviewMode(true);
         settings.setUseWideViewPort(true);
 
+        Runnable onReady = enableInitHandshake
+                ? () -> activity.runOnUiThread(this::sendInit)
+                : null;
+
         webView.addJavascriptInterface(
                 new AndroidBridge(
                         () -> activity.runOnUiThread(this::dismiss),
-                        () -> activity.runOnUiThread(this::sendInit)),
+                        onReady),
                 "AndroidBridge");
 
         webView.setWebViewClient(new WebViewClient() {
@@ -103,7 +126,7 @@ class WidgetDialog {
         dialog.show();
     }
 
-    private void dismiss() {
+    void dismiss() {
         if (dialog.isShowing()) {
             dialog.dismiss();
         }
@@ -117,8 +140,8 @@ class WidgetDialog {
     }
 
     /**
-     * Called when the widget fires its READY signal. Posts INIT back via window.postMessage
-     * so the widget bridge picks up the userId/token.
+     * Called when the loyalty widget fires its READY signal. Posts INIT back via
+     * window.postMessage so the widget bridge picks up the userId/token.
      */
     private void sendInit() {
         String initJson = buildInitJson();

--- a/OptimoveSDK/optimove-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.java
+++ b/OptimoveSDK/optimove-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/AndroidBridgeTest.java
@@ -31,4 +31,20 @@ public class AndroidBridgeTest {
         bridge.receiveMessage("{\"type\":\"TEST\"}");
         verify(onReady, never()).run();
     }
+
+    @Test
+    public void receiveMessage_invokesOnCloseForCloseType() {
+        Runnable onClose = mock(Runnable.class);
+        AndroidBridge bridge = new AndroidBridge(onClose, mock(Runnable.class));
+        bridge.receiveMessage("{\"type\":\"CLOSE\"}");
+        verify(onClose).run();
+    }
+
+    @Test
+    public void receiveMessage_readyIsNoOpWhenOnReadyNull() {
+        Runnable onClose = mock(Runnable.class);
+        AndroidBridge bridge = new AndroidBridge(onClose, null);
+        bridge.receiveMessage("{\"type\":\"READY\"}");
+        verify(onClose, never()).run();
+    }
 }

--- a/OptimoveSDK/optimove-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDKTest.java
+++ b/OptimoveSDK/optimove-sdk/src/test/java/com/optimove/android/gamifywidgetsdk/GamifyWidgetSDKTest.java
@@ -1,13 +1,20 @@
 package com.optimove.android.gamifywidgetsdk;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Field;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class GamifyWidgetSDKTest {
 
     @Test
@@ -29,6 +36,58 @@ public class GamifyWidgetSDKTest {
         GamifyWidgetSDK.initialize("https://first.example.com");
         GamifyWidgetSDK.initialize("https://second.example.com");
         assertSame(GamifyWidgetSDK.getInstance(), GamifyWidgetSDK.getInstance());
+    }
+
+    @Test
+    public void getAdactUrl_returnsNormalizedTrailingSlash() throws Exception {
+        resetShared();
+        GamifyWidgetSDK.initialize("https://loyalty.example.com", "https://campaign.adact.me/");
+        assertEquals("https://campaign.adact.me/", GamifyWidgetSDK.getInstance().getAdactUrl());
+    }
+
+    @Test
+    public void getAdactUrl_emptyWhenNotConfigured() throws Exception {
+        resetShared();
+        GamifyWidgetSDK.initialize("https://loyalty.example.com");
+        assertEquals("", GamifyWidgetSDK.getInstance().getAdactUrl());
+    }
+
+    @Test
+    public void buildAdactCampaignUrl_buildsEmbeddedPath() throws Exception {
+        resetShared();
+        GamifyWidgetSDK.initialize(null, "https://campaign.adact.me/");
+        assertEquals(
+                "https://campaign.adact.me/embedded/179",
+                GamifyWidgetSDK.getInstance().buildAdactCampaignUrl(new OpenAdactParams(179, null, null)));
+    }
+
+    @Test
+    public void buildAdactCampaignUrl_addsCidAndCustomerIdToken() throws Exception {
+        resetShared();
+        GamifyWidgetSDK.initialize(null, "https://campaign.adact.me/");
+        String url = GamifyWidgetSDK.getInstance().buildAdactCampaignUrl(
+                new OpenAdactParams(179, "customer@example.com", "jwt-token"));
+        assertTrue(url.startsWith("https://campaign.adact.me/embedded/179?"));
+        assertTrue(url.contains("cid=customer%40example.com") || url.contains("cid=customer@example.com"));
+        assertTrue(url.contains("customerIdToken=jwt-token"));
+    }
+
+    @Test
+    public void buildAdactCampaignUrl_emptyWhenAdactUrlOrCampaignIdMissing() throws Exception {
+        resetShared();
+        GamifyWidgetSDK.initialize("https://loyalty.example.com");
+        assertEquals("", GamifyWidgetSDK.getInstance().buildAdactCampaignUrl(new OpenAdactParams(179, null, null)));
+
+        resetShared();
+        GamifyWidgetSDK.initialize(null, "https://campaign.adact.me/");
+        assertEquals("", GamifyWidgetSDK.getInstance().buildAdactCampaignUrl(new OpenAdactParams(null, "cid", null)));
+    }
+
+    @Test
+    public void buildAdactCampaignUrl_rejectsNonHttps() throws Exception {
+        resetShared();
+        GamifyWidgetSDK.initialize(null, "http://campaign.adact.me/");
+        assertEquals("", GamifyWidgetSDK.getInstance().buildAdactCampaignUrl(new OpenAdactParams(179, null, null)));
     }
 
     private static void resetShared() throws Exception {


### PR DESCRIPTION
## Summary
Adds **Adact mini games** support to `GamifyWidgetSDK` so Android apps can open embedded campaigns in a fullscreen WebView dialog, matching the Web / iOS contract.

## What's included
- `initialize(widgetUrl, adactUrl)` — optional `adactUrl` from onboarding/retrieval (SDK does not map regions)
- API:
  - `openAdactCampaign(activity, OpenAdactParams)`
  - `closeAdactCampaign()` / `closeWidget()`
  - `buildAdactCampaignUrl(...)` / `getAdactUrl()`
- `OpenAdactParams` (`campaignId`, `cid?`, `token?`)
- Builds `{adactUrl}/embedded/{campaignId}?cid=&customerIdToken=`
- No loyalty READY→INIT handshake for Adact (identity via query params)
- Loyalty and Adact are independent surfaces; only one fullscreen overlay at a time
- Bridge handles `{ type: "CLOSE" }` in addition to `closeWidget()`
- Demo app: Adact section on Gamify screen (URL, campaign ID, cid, token)
- Version bump to **7.16.0** (`gradle.properties` + CHANGELOG)
- Unit tests for URL building / initialize; ProGuard keep for `OpenAdactParams`

## Test plan
- [ ] Run demo app → Open Gamify Widget → Adact section → open campaign
- [ ] Confirm WebView loads `/embedded/{campaignId}` with optional `cid` / `customerIdToken`
- [ ] Missing `adactUrl` / `campaignId` / non-HTTPS → no-op
- [ ] `closeAdactCampaign()` closes Adact only; `closeWidget()` closes loyalty only
- [ ] Opening Adact closes an open loyalty overlay (and the reverse)
- [ ] Unit tests: `com.optimove.android.gamifywidgetsdk.*` pass